### PR TITLE
Add default_detector metadata field for all wires

### DIFF
--- a/slac_db/package_data/wire_metadata.yaml
+++ b/slac_db/package_data/wire_metadata.yaml
@@ -3,6 +3,7 @@ WS01:
     - PMTINJ03:DL1
     - PMTINJ05:DL1
     - PMT21350:LI21
+  default_detector: PMTINJ03:DL1
   wire_type: slow
 
 WS02:
@@ -10,6 +11,7 @@ WS02:
     - PMTINJ03:DL1
     - PMTINJ05:DL1
     - PMT21350:LI21
+  default_detector: PMTINJ03:DL1
   wire_type: fast
 
 WS03:
@@ -17,6 +19,7 @@ WS03:
     - PMTINJ03:DL1
     - PMTINJ05:DL1
     - PMT21350:LI21
+  default_detector: PMTINJ03:DL1
   wire_type: fast
 
 WS04:
@@ -24,6 +27,7 @@ WS04:
     - PMTINJ03:DL1
     - PMTINJ05:DL1
     - PMT21350:LI21
+  default_detector: PMTINJ05:DL1
   wire_type: slow
 
 WS11:
@@ -34,6 +38,7 @@ WS11:
     - PMT21350:LI21
     - PMT2114:LI21
     - PMT2115:LI21
+  default_detector: PMT21350:LI21
   wire_type: fast
 
 WS12:
@@ -44,6 +49,7 @@ WS12:
     - PMT21350:LI21
     - PMT2114:LI21
     - PMT2115:LI21
+  default_detector: PMT21350:LI21
   wire_type: fast
 
 WS13:
@@ -54,12 +60,14 @@ WS13:
     - PMT21350:LI21
     - PMT2114:LI21
     - PMT2115:LI21
+  default_detector: PMT21350:LI21
   wire_type: fast
 
 WS24:
   detectors:
     - PMT24705:LI24
     - PMT24706:LI24
+  default_detector: PMT24705:LI24
   wire_type: slow
 
 WS27644:
@@ -67,6 +75,7 @@ WS27644:
     - PMT29150:LI29
     - PMT756:LTUH
     - PMT820:LTUH
+  default_detector: PMT29150:LI29
   wire_type: fast
 
 WS28144:
@@ -74,6 +83,7 @@ WS28144:
     - PMT29150:LI29
     - PMT756:LTUH
     - PMT820:LTUH
+  default_detector: PMT29150:LI29
   wire_type: fast
 
 WS28444:
@@ -81,6 +91,7 @@ WS28444:
     - PMT29150:LI29
     - PMT756:LTUH
     - PMT820:LTUH
+  default_detector: PMT29150:LI29
   wire_type: fast
 
 WS28744:
@@ -88,12 +99,15 @@ WS28744:
     - PMT29150:LI29
     - PMT756:LTUH
     - PMT820:LTUH
+  default_detector: PMT29150:LI29
   wire_type: fast
 
 WS0H04:
   detectors:
     - LBLM01A:HTR
     - LBLM01B:HTR
+    - TMITLOSS:HTR
+  default_detector: TMITLOSS:HTR
   bpms_before_wire:
     - BPMS:GUNB:925
     - BPMS:HTR:120
@@ -110,6 +124,7 @@ WSDG01:
     - SBLM01A:DIAG0
     - LBLM01A:HTR
     - LBLM01B:HTR
+  default_detector: LBLM01A:HTR
   bpms_before_wire:
     - BPMS:DIAG0:190
     - BPMS:DIAG0:210
@@ -129,6 +144,7 @@ WSC104:
     - LBLM03A:L1B
     - LBLM04A:L2B
     - TMITLOSS:COL1
+  default_detector: TMITLOSS:COL1
   bpms_before_wire:
     - BPMS:BC1B:125
     - BPMS:BC1B:440
@@ -152,6 +168,7 @@ WSC106:
     - LBLM03A:L1B
     - LBLM04A:L2B
     - TMITLOSS:COL1
+  default_detector: TMITLOSS:COL1
   bpms_before_wire:
     - BPMS:BC1B:125
     - BPMS:BC1B:440
@@ -175,6 +192,7 @@ WSC108:
     - LBLM03A:L1B
     - LBLM04A:L2B
     - TMITLOSS:COL1
+  default_detector: TMITLOSS:COL1
   bpms_before_wire:
     - BPMS:BC1B:125
     - BPMS:BC1B:440
@@ -198,6 +216,7 @@ WSC110:
     - LBLM03A:L1B
     - LBLM04A:L2B
     - TMITLOSS:COL1
+  default_detector: TMITLOSS:COL1
   bpms_before_wire:
     - BPMS:BC1B:125
     - BPMS:BC1B:440
@@ -221,6 +240,7 @@ WSEMIT2:
     - LBLM04A:L2B
     - LBLM07A:L3B
     - TMITLOSS:EMIT2
+  default_detector: TMITLOSS:EMIT2
   bpms_before_wire:
     - BPMS:BC2B:150
     - BPMS:BC2B:530
@@ -241,6 +261,7 @@ WSBP1:
     - LBLM11A_2:BYP
     - LBLM11A_3:BYP
     - TMITLOSS:BYP
+  default_detector: TMITLOSS:BYP
   bpms_before_wire:
     - BPMS:L3B:3583
     - BPMS:EXT:351
@@ -279,6 +300,7 @@ WSBP2:
     - LBLM11A_2:BYP
     - LBLM11A_3:BYP
     - TMITLOSS:BYP
+  default_detector: TMITLOSS:BYP
   bpms_before_wire:
     - BPMS:L3B:3583
     - BPMS:EXT:351
@@ -317,6 +339,7 @@ WSBP3:
     - LBLM11A_2:BYP
     - LBLM11A_3:BYP
     - TMITLOSS:BYP
+  default_detector: TMITLOSS:BYP
   bpms_before_wire:
     - BPMS:L3B:3583
     - BPMS:EXT:351
@@ -355,6 +378,7 @@ WSBP4:
     - LBLM11A_2:BYP
     - LBLM11A_3:BYP
     - TMITLOSS:BYP
+  default_detector: TMITLOSS:BYP
   bpms_before_wire:
     - BPMS:L3B:3583
     - BPMS:EXT:351
@@ -390,6 +414,7 @@ WSBP4:
 WSSP1D:
   detectors:
     - LBLM22A:SPS
+  default_detector: LBLM22A:SPS
   bpms_before_wire:
     - BPMS:SPD:135
     - BPMS:SPD:255
@@ -415,6 +440,7 @@ WS31:
     - PMT820:LTUH
     - PMT850:LTUH
     - LBLM32A:LTUH
+  default_detector: LBLM32A:LTUH
   wire_type: fast
 
 WS32:
@@ -429,6 +455,7 @@ WS32:
     - PMT820:LTUH
     - PMT850:LTUH
     - LBLM32A:LTUH
+  default_detector: LBLM32A:LTUH
   wire_type: fast
 
 WS33:
@@ -443,6 +470,7 @@ WS33:
     - PMT820:LTUH
     - PMT850:LTUH
     - LBLM32A:LTUH
+  default_detector: LBLM32A:LTUH
   wire_type: fast
 
 WS34:
@@ -457,12 +485,14 @@ WS34:
     - PMT820:LTUH
     - PMT850:LTUH
     - LBLM32A:LTUH
+  default_detector: LBLM32A:LTUH
   wire_type: fast
 
 WS31B:
   detectors:
     - LBLMS32A:LTUS
     - TMITLOSS:LTUS
+  default_detector: TMITLOSS:LTUS
   bpms_before_wire:
     - BPMS:BPN27:400
     - BPMS:BPN28:200
@@ -489,6 +519,7 @@ WS32B:
   detectors:
     - LBLMS32A:LTUS
     - TMITLOSS:LTUS
+  default_detector: TMITLOSS:LTUS
   bpms_before_wire:
     - BPMS:BPN27:400
     - BPMS:BPN28:200
@@ -515,6 +546,7 @@ WS33B:
   detectors:
     - LBLMS32A:LTUS
     - TMITLOSS:LTUS
+  default_detector: TMITLOSS:LTUS
   bpms_before_wire:
     - BPMS:BPN27:400
     - BPMS:BPN28:200
@@ -541,6 +573,7 @@ WS34B:
   detectors:
     - LBLMS32A:LTUS
     - TMITLOSS:LTUS
+  default_detector: TMITLOSS:LTUS
   bpms_before_wire:
     - BPMS:BPN27:400
     - BPMS:BPN28:200

--- a/slac_db/yaml/BC1.yaml
+++ b/slac_db/yaml/BC1.yaml
@@ -706,6 +706,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      default_detector: PMT21350:LI21
       detectors:
       - PMT2111:DL1
       - PMT21293:LI21
@@ -760,6 +761,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      default_detector: PMT21350:LI21
       detectors:
       - PMT2111:DL1
       - PMT21293:LI21
@@ -814,6 +816,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      default_detector: PMT21350:LI21
       detectors:
       - PMT2111:DL1
       - PMT21293:LI21

--- a/slac_db/yaml/BC2.yaml
+++ b/slac_db/yaml/BC2.yaml
@@ -397,6 +397,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      default_detector: PMT24705:LI24
       detectors:
       - PMT24705:LI24
       - PMT24706:LI24

--- a/slac_db/yaml/BYP.yaml
+++ b/slac_db/yaml/BYP.yaml
@@ -1804,6 +1804,7 @@ wires:
       - BPMS:DOG:335
       - BPMS:DOG:355
       - BPMS:DOG:405
+      default_detector: TMITLOSS:BYP
       detectors:
       - LBLM11A_1:BYP
       - LBLM11A_2:BYP
@@ -1888,6 +1889,7 @@ wires:
       - BPMS:DOG:335
       - BPMS:DOG:355
       - BPMS:DOG:405
+      default_detector: TMITLOSS:BYP
       detectors:
       - LBLM11A_1:BYP
       - LBLM11A_2:BYP
@@ -1972,6 +1974,7 @@ wires:
       - BPMS:DOG:335
       - BPMS:DOG:355
       - BPMS:DOG:405
+      default_detector: TMITLOSS:BYP
       detectors:
       - LBLM11A_1:BYP
       - LBLM11A_2:BYP

--- a/slac_db/yaml/COL1.yaml
+++ b/slac_db/yaml/COL1.yaml
@@ -878,6 +878,7 @@ wires:
       - BPMS:COL1:260
       - BPMS:COL1:280
       - BPMS:COL1:320
+      default_detector: TMITLOSS:COL1
       detectors:
       - LBLM03A:L1B
       - LBLM04A:L2B
@@ -947,6 +948,7 @@ wires:
       - BPMS:COL1:260
       - BPMS:COL1:280
       - BPMS:COL1:320
+      default_detector: TMITLOSS:COL1
       detectors:
       - LBLM03A:L1B
       - LBLM04A:L2B
@@ -1016,6 +1018,7 @@ wires:
       - BPMS:COL1:260
       - BPMS:COL1:280
       - BPMS:COL1:320
+      default_detector: TMITLOSS:COL1
       detectors:
       - LBLM03A:L1B
       - LBLM04A:L2B
@@ -1085,6 +1088,7 @@ wires:
       - BPMS:COL1:260
       - BPMS:COL1:280
       - BPMS:COL1:320
+      default_detector: TMITLOSS:COL1
       detectors:
       - LBLM03A:L1B
       - LBLM04A:L2B

--- a/slac_db/yaml/DIAG0.yaml
+++ b/slac_db/yaml/DIAG0.yaml
@@ -768,6 +768,7 @@ wires:
       - BPMS:DIAG0:330
       - BPMS:DIAG0:370
       - BPMS:DIAG0:390
+      default_detector: LBLM01A:HTR
       detectors:
       - SBLM01A:DIAG0
       - LBLM01A:HTR

--- a/slac_db/yaml/DL1.yaml
+++ b/slac_db/yaml/DL1.yaml
@@ -1117,6 +1117,7 @@ wires:
       - CU_SFTH
       - CU_SPEC
       - CU_SXR
+      default_detector: PMTINJ03:DL1
       detectors:
       - PMTINJ03:DL1
       - PMTINJ05:DL1
@@ -1167,6 +1168,7 @@ wires:
       - CU_SFTH
       - CU_SPEC
       - CU_SXR
+      default_detector: PMTINJ03:DL1
       detectors:
       - PMTINJ03:DL1
       - PMTINJ05:DL1
@@ -1217,6 +1219,7 @@ wires:
       - CU_SFTH
       - CU_SPEC
       - CU_SXR
+      default_detector: PMTINJ03:DL1
       detectors:
       - PMTINJ03:DL1
       - PMTINJ05:DL1
@@ -1260,6 +1263,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      default_detector: PMTINJ05:DL1
       detectors:
       - PMTINJ03:DL1
       - PMTINJ05:DL1

--- a/slac_db/yaml/DOG.yaml
+++ b/slac_db/yaml/DOG.yaml
@@ -1505,6 +1505,7 @@ wires:
       - BPMS:DOG:335
       - BPMS:DOG:355
       - BPMS:DOG:405
+      default_detector: TMITLOSS:BYP
       detectors:
       - LBLM11A_1:BYP
       - LBLM11A_2:BYP

--- a/slac_db/yaml/EMIT2.yaml
+++ b/slac_db/yaml/EMIT2.yaml
@@ -339,6 +339,7 @@ wires:
       - BPMS:BC2B:530
       - BPMS:EMIT2:150
       - BPMS:EMIT2:300
+      default_detector: TMITLOSS:EMIT2
       detectors:
       - LBLM04A:L2B
       - LBLM07A:L3B

--- a/slac_db/yaml/HTR.yaml
+++ b/slac_db/yaml/HTR.yaml
@@ -1160,9 +1160,11 @@ wires:
       - BPMS:GUNB:925
       - BPMS:HTR:120
       - BPMS:HTR:320
+      default_detector: TMITLOSS:HTR
       detectors:
       - LBLM01A:HTR
       - LBLM01B:HTR
+      - TMITLOSS:HTR
       sum_l_meters: 24.589
       type: WIRE
       wire_type: fast

--- a/slac_db/yaml/L3.yaml
+++ b/slac_db/yaml/L3.yaml
@@ -4398,6 +4398,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      default_detector: PMT29150:LI29
       detectors:
       - PMT29150:LI29
       - PMT756:LTUH
@@ -4449,6 +4450,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      default_detector: PMT29150:LI29
       detectors:
       - PMT29150:LI29
       - PMT756:LTUH
@@ -4500,6 +4502,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      default_detector: PMT29150:LI29
       detectors:
       - PMT29150:LI29
       - PMT756:LTUH
@@ -4551,6 +4554,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      default_detector: PMT29150:LI29
       detectors:
       - PMT29150:LI29
       - PMT756:LTUH

--- a/slac_db/yaml/LTUH.yaml
+++ b/slac_db/yaml/LTUH.yaml
@@ -2926,6 +2926,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - SC_HXR
+      default_detector: LBLM32A:LTUH
       detectors:
       - PMT122:LTUH
       - PMT246:LTUH
@@ -2983,6 +2984,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - SC_HXR
+      default_detector: LBLM32A:LTUH
       detectors:
       - PMT122:LTUH
       - PMT246:LTUH
@@ -3040,6 +3042,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - SC_HXR
+      default_detector: LBLM32A:LTUH
       detectors:
       - PMT122:LTUH
       - PMT246:LTUH
@@ -3097,6 +3100,7 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - SC_HXR
+      default_detector: LBLM32A:LTUH
       detectors:
       - PMT122:LTUH
       - PMT246:LTUH

--- a/slac_db/yaml/LTUS.yaml
+++ b/slac_db/yaml/LTUS.yaml
@@ -2838,6 +2838,7 @@ wires:
       - BPMS:SPS:830
       - BPMS:SPS:840
       - BPMS:SLTS:150
+      default_detector: TMITLOSS:LTUS
       detectors:
       - LBLMS32A:LTUS
       - TMITLOSS:LTUS
@@ -2908,6 +2909,7 @@ wires:
       - BPMS:SPS:830
       - BPMS:SPS:840
       - BPMS:SLTS:150
+      default_detector: TMITLOSS:LTUS
       detectors:
       - LBLMS32A:LTUS
       - TMITLOSS:LTUS
@@ -2978,6 +2980,7 @@ wires:
       - BPMS:SPS:830
       - BPMS:SPS:840
       - BPMS:SLTS:150
+      default_detector: TMITLOSS:LTUS
       detectors:
       - LBLMS32A:LTUS
       - TMITLOSS:LTUS
@@ -3048,6 +3051,7 @@ wires:
       - BPMS:SPS:830
       - BPMS:SPS:840
       - BPMS:SLTS:150
+      default_detector: TMITLOSS:LTUS
       detectors:
       - LBLMS32A:LTUS
       - TMITLOSS:LTUS

--- a/slac_db/yaml/SPD.yaml
+++ b/slac_db/yaml/SPD.yaml
@@ -415,6 +415,7 @@ wires:
       - BPMS:SPD:420
       - BPMS:SPD:525
       - BPMS:SPD:570
+      default_detector: LBLM22A:SPS
       detectors:
       - LBLM22A:SPS
       sum_l_meters: 3024.92


### PR DESCRIPTION
I've added a new metadata field `default_detector` to keep metadata consolidated in a single place.  YAML files have been updated to reflect this change.  See Issue #26 