### PR TITLE
Add new status mappings for MOTR and SCAN in YAMLGenerator

### DIFF
--- a/slac_db/generate.py
+++ b/slac_db/generate.py
@@ -400,8 +400,10 @@ class YAMLGenerator:
             "MOTR": "motor",
             "MOTR.RBV": "motor_rbv",
             "MPSSPEED": "mps_speed",
+            "MOTR_ON_STS": "on_status",
             "MOTR_RETRACT": "retract",
             "SCANPULSES": "scan_pulses",
+            "SCANSTAT": "scan_status", # on-the-fly status only
             "MOTR.VELO": "speed",
             "MOTR.VMAX": "speed_max",
             "MOTR.VBAS": "speed_min",

--- a/slac_db/package_data/yaml/BC1.yaml
+++ b/slac_db/package_data/yaml/BC1.yaml
@@ -675,8 +675,10 @@ wires:
         motor: WIRE:LI21:285:MOTR
         motor_rbv: WIRE:LI21:285:MOTR.RBV
         mps_speed: WIRE:LI21:285:MPSSPEED
+        on_status: WIRE:LI21:285:MOTR_ON_STS
         retract: WIRE:LI21:285:MOTR_RETRACT
         scan_pulses: WIRE:LI21:285:SCANPULSES
+        scan_status: WIRE:LI21:285:SCANSTAT
         speed: WIRE:LI21:285:MOTR.VELO
         speed_max: WIRE:LI21:285:MOTR.VMAX
         speed_min: WIRE:LI21:285:MOTR.VBAS
@@ -730,8 +732,10 @@ wires:
         motor: WIRE:LI21:293:MOTR
         motor_rbv: WIRE:LI21:293:MOTR.RBV
         mps_speed: WIRE:LI21:293:MPSSPEED
+        on_status: WIRE:LI21:293:MOTR_ON_STS
         retract: WIRE:LI21:293:MOTR_RETRACT
         scan_pulses: WIRE:LI21:293:SCANPULSES
+        scan_status: WIRE:LI21:293:SCANSTAT
         speed: WIRE:LI21:293:MOTR.VELO
         speed_max: WIRE:LI21:293:MOTR.VMAX
         speed_min: WIRE:LI21:293:MOTR.VBAS
@@ -785,8 +789,10 @@ wires:
         motor: WIRE:LI21:301:MOTR
         motor_rbv: WIRE:LI21:301:MOTR.RBV
         mps_speed: WIRE:LI21:301:MPSSPEED
+        on_status: WIRE:LI21:301:MOTR_ON_STS
         retract: WIRE:LI21:301:MOTR_RETRACT
         scan_pulses: WIRE:LI21:301:SCANPULSES
+        scan_status: WIRE:LI21:301:SCANSTAT
         speed: WIRE:LI21:301:MOTR.VELO
         speed_max: WIRE:LI21:301:MOTR.VMAX
         speed_min: WIRE:LI21:301:MOTR.VBAS

--- a/slac_db/package_data/yaml/BYP.yaml
+++ b/slac_db/package_data/yaml/BYP.yaml
@@ -1741,8 +1741,10 @@ wires:
         motor: WIRE:BPN12:850:MOTR
         motor_rbv: WIRE:BPN12:850:MOTR.RBV
         mps_speed: WIRE:BPN12:850:MPSSPEED
+        on_status: WIRE:BPN12:850:MOTR_ON_STS
         retract: WIRE:BPN12:850:MOTR_RETRACT
         scan_pulses: WIRE:BPN12:850:SCANPULSES
+        scan_status: WIRE:BPN12:850:SCANSTAT
         speed: WIRE:BPN12:850:MOTR.VELO
         speed_max: WIRE:BPN12:850:MOTR.VMAX
         speed_min: WIRE:BPN12:850:MOTR.VBAS
@@ -1826,8 +1828,10 @@ wires:
         motor: WIRE:BPN14:850:MOTR
         motor_rbv: WIRE:BPN14:850:MOTR.RBV
         mps_speed: WIRE:BPN14:850:MPSSPEED
+        on_status: WIRE:BPN14:850:MOTR_ON_STS
         retract: WIRE:BPN14:850:MOTR_RETRACT
         scan_pulses: WIRE:BPN14:850:SCANPULSES
+        scan_status: WIRE:BPN14:850:SCANSTAT
         speed: WIRE:BPN14:850:MOTR.VELO
         speed_max: WIRE:BPN14:850:MOTR.VMAX
         speed_min: WIRE:BPN14:850:MOTR.VBAS
@@ -1911,8 +1915,10 @@ wires:
         motor: WIRE:BPN16:850:MOTR
         motor_rbv: WIRE:BPN16:850:MOTR.RBV
         mps_speed: WIRE:BPN16:850:MPSSPEED
+        on_status: WIRE:BPN16:850:MOTR_ON_STS
         retract: WIRE:BPN16:850:MOTR_RETRACT
         scan_pulses: WIRE:BPN16:850:SCANPULSES
+        scan_status: WIRE:BPN16:850:SCANSTAT
         speed: WIRE:BPN16:850:MOTR.VELO
         speed_max: WIRE:BPN16:850:MOTR.VMAX
         speed_min: WIRE:BPN16:850:MOTR.VBAS

--- a/slac_db/package_data/yaml/COL1.yaml
+++ b/slac_db/package_data/yaml/COL1.yaml
@@ -829,8 +829,10 @@ wires:
         motor: WIRE:COL1:360:MOTR
         motor_rbv: WIRE:COL1:360:MOTR.RBV
         mps_speed: WIRE:COL1:360:MPSSPEED
+        on_status: WIRE:COL1:360:MOTR_ON_STS
         retract: WIRE:COL1:360:MOTR_RETRACT
         scan_pulses: WIRE:COL1:360:SCANPULSES
+        scan_status: WIRE:COL1:360:SCANSTAT
         speed: WIRE:COL1:360:MOTR.VELO
         speed_max: WIRE:COL1:360:MOTR.VMAX
         speed_min: WIRE:COL1:360:MOTR.VBAS
@@ -899,8 +901,10 @@ wires:
         motor: WIRE:COL1:520:MOTR
         motor_rbv: WIRE:COL1:520:MOTR.RBV
         mps_speed: WIRE:COL1:520:MPSSPEED
+        on_status: WIRE:COL1:520:MOTR_ON_STS
         retract: WIRE:COL1:520:MOTR_RETRACT
         scan_pulses: WIRE:COL1:520:SCANPULSES
+        scan_status: WIRE:COL1:520:SCANSTAT
         speed: WIRE:COL1:520:MOTR.VELO
         speed_max: WIRE:COL1:520:MOTR.VMAX
         speed_min: WIRE:COL1:520:MOTR.VBAS
@@ -969,8 +973,10 @@ wires:
         motor: WIRE:COL1:680:MOTR
         motor_rbv: WIRE:COL1:680:MOTR.RBV
         mps_speed: WIRE:COL1:680:MPSSPEED
+        on_status: WIRE:COL1:680:MOTR_ON_STS
         retract: WIRE:COL1:680:MOTR_RETRACT
         scan_pulses: WIRE:COL1:680:SCANPULSES
+        scan_status: WIRE:COL1:680:SCANSTAT
         speed: WIRE:COL1:680:MOTR.VELO
         speed_max: WIRE:COL1:680:MOTR.VMAX
         speed_min: WIRE:COL1:680:MOTR.VBAS
@@ -1039,8 +1045,10 @@ wires:
         motor: WIRE:COL1:840:MOTR
         motor_rbv: WIRE:COL1:840:MOTR.RBV
         mps_speed: WIRE:COL1:840:MPSSPEED
+        on_status: WIRE:COL1:840:MOTR_ON_STS
         retract: WIRE:COL1:840:MOTR_RETRACT
         scan_pulses: WIRE:COL1:840:SCANPULSES
+        scan_status: WIRE:COL1:840:SCANSTAT
         speed: WIRE:COL1:840:MOTR.VELO
         speed_max: WIRE:COL1:840:MOTR.VMAX
         speed_min: WIRE:COL1:840:MOTR.VBAS

--- a/slac_db/package_data/yaml/DL1.yaml
+++ b/slac_db/package_data/yaml/DL1.yaml
@@ -1136,6 +1136,7 @@ wires:
         install_angle: WIRE:IN20:561:INSTALLANGLE
         motor: WIRE:IN20:561:MOTR
         motor_rbv: WIRE:IN20:561:MOTR.RBV
+        on_status: WIRE:IN20:561:MOTR_ON_STS
         retract: WIRE:IN20:561:MOTR_RETRACT
         scan_pulses: WIRE:IN20:561:SCANPULSES
         speed: WIRE:IN20:561:MOTR.VELO
@@ -1187,6 +1188,7 @@ wires:
         install_angle: WIRE:IN20:611:INSTALLANGLE
         motor: WIRE:IN20:611:MOTR
         motor_rbv: WIRE:IN20:611:MOTR.RBV
+        on_status: WIRE:IN20:611:MOTR_ON_STS
         retract: WIRE:IN20:611:MOTR_RETRACT
         scan_pulses: WIRE:IN20:611:SCANPULSES
         speed: WIRE:IN20:611:MOTR.VELO

--- a/slac_db/package_data/yaml/EMIT2.yaml
+++ b/slac_db/package_data/yaml/EMIT2.yaml
@@ -294,8 +294,10 @@ wires:
         motor: WIRE:EMIT2:600:MOTR
         motor_rbv: WIRE:EMIT2:600:MOTR.RBV
         mps_speed: WIRE:EMIT2:600:MPSSPEED
+        on_status: WIRE:EMIT2:600:MOTR_ON_STS
         retract: WIRE:EMIT2:600:MOTR_RETRACT
         scan_pulses: WIRE:EMIT2:600:SCANPULSES
+        scan_status: WIRE:EMIT2:600:SCANSTAT
         speed: WIRE:EMIT2:600:MOTR.VELO
         speed_max: WIRE:EMIT2:600:MOTR.VMAX
         speed_min: WIRE:EMIT2:600:MOTR.VBAS

--- a/slac_db/package_data/yaml/HTR.yaml
+++ b/slac_db/package_data/yaml/HTR.yaml
@@ -1117,8 +1117,10 @@ wires:
         motor: WIRE:HTR:340:MOTR
         motor_rbv: WIRE:HTR:340:MOTR.RBV
         mps_speed: WIRE:HTR:340:MPSSPEED
+        on_status: WIRE:HTR:340:MOTR_ON_STS
         retract: WIRE:HTR:340:MOTR_RETRACT
         scan_pulses: WIRE:HTR:340:SCANPULSES
+        scan_status: WIRE:HTR:340:SCANSTAT
         speed: WIRE:HTR:340:MOTR.VELO
         speed_max: WIRE:HTR:340:MOTR.VMAX
         speed_min: WIRE:HTR:340:MOTR.VBAS

--- a/slac_db/package_data/yaml/L3.yaml
+++ b/slac_db/package_data/yaml/L3.yaml
@@ -4367,8 +4367,10 @@ wires:
         motor: WIRE:LI27:644:MOTR
         motor_rbv: WIRE:LI27:644:MOTR.RBV
         mps_speed: WIRE:LI27:644:MPSSPEED
+        on_status: WIRE:LI27:644:MOTR_ON_STS
         retract: WIRE:LI27:644:MOTR_RETRACT
         scan_pulses: WIRE:LI27:644:SCANPULSES
+        scan_status: WIRE:LI27:644:SCANSTAT
         speed: WIRE:LI27:644:MOTR.VELO
         speed_max: WIRE:LI27:644:MOTR.VMAX
         speed_min: WIRE:LI27:644:MOTR.VBAS
@@ -4419,8 +4421,10 @@ wires:
         motor: WIRE:LI28:144:MOTR
         motor_rbv: WIRE:LI28:144:MOTR.RBV
         mps_speed: WIRE:LI28:144:MPSSPEED
+        on_status: WIRE:LI28:144:MOTR_ON_STS
         retract: WIRE:LI28:144:MOTR_RETRACT
         scan_pulses: WIRE:LI28:144:SCANPULSES
+        scan_status: WIRE:LI28:144:SCANSTAT
         speed: WIRE:LI28:144:MOTR.VELO
         speed_max: WIRE:LI28:144:MOTR.VMAX
         speed_min: WIRE:LI28:144:MOTR.VBAS
@@ -4471,8 +4475,10 @@ wires:
         motor: WIRE:LI28:444:MOTR
         motor_rbv: WIRE:LI28:444:MOTR.RBV
         mps_speed: WIRE:LI28:444:MPSSPEED
+        on_status: WIRE:LI28:444:MOTR_ON_STS
         retract: WIRE:LI28:444:MOTR_RETRACT
         scan_pulses: WIRE:LI28:444:SCANPULSES
+        scan_status: WIRE:LI28:444:SCANSTAT
         speed: WIRE:LI28:444:MOTR.VELO
         speed_max: WIRE:LI28:444:MOTR.VMAX
         speed_min: WIRE:LI28:444:MOTR.VBAS
@@ -4523,8 +4529,10 @@ wires:
         motor: WIRE:LI28:744:MOTR
         motor_rbv: WIRE:LI28:744:MOTR.RBV
         mps_speed: WIRE:LI28:744:MPSSPEED
+        on_status: WIRE:LI28:744:MOTR_ON_STS
         retract: WIRE:LI28:744:MOTR_RETRACT
         scan_pulses: WIRE:LI28:744:SCANPULSES
+        scan_status: WIRE:LI28:744:SCANSTAT
         speed: WIRE:LI28:744:MOTR.VELO
         speed_max: WIRE:LI28:744:MOTR.VMAX
         speed_min: WIRE:LI28:744:MOTR.VBAS

--- a/slac_db/package_data/yaml/LI27.yaml
+++ b/slac_db/package_data/yaml/LI27.yaml
@@ -43,8 +43,10 @@ wires:
         motor: WIRE:LI27:644:MOTR
         motor_rbv: WIRE:LI27:644:MOTR.RBV
         mps_speed: WIRE:LI27:644:MPSSPEED
+        on_status: WIRE:LI27:644:MOTR_ON_STS
         retract: WIRE:LI27:644:MOTR_RETRACT
         scan_pulses: WIRE:LI27:644:SCANPULSES
+        scan_status: WIRE:LI27:644:SCANSTAT
         speed: WIRE:LI27:644:MOTR.VELO
         speed_max: WIRE:LI27:644:MOTR.VMAX
         speed_min: WIRE:LI27:644:MOTR.VBAS

--- a/slac_db/package_data/yaml/LI28.yaml
+++ b/slac_db/package_data/yaml/LI28.yaml
@@ -79,8 +79,10 @@ wires:
         motor: WIRE:LI28:144:MOTR
         motor_rbv: WIRE:LI28:144:MOTR.RBV
         mps_speed: WIRE:LI28:144:MPSSPEED
+        on_status: WIRE:LI28:144:MOTR_ON_STS
         retract: WIRE:LI28:144:MOTR_RETRACT
         scan_pulses: WIRE:LI28:144:SCANPULSES
+        scan_status: WIRE:LI28:144:SCANSTAT
         speed: WIRE:LI28:144:MOTR.VELO
         speed_max: WIRE:LI28:144:MOTR.VMAX
         speed_min: WIRE:LI28:144:MOTR.VBAS
@@ -119,8 +121,10 @@ wires:
         motor: WIRE:LI28:444:MOTR
         motor_rbv: WIRE:LI28:444:MOTR.RBV
         mps_speed: WIRE:LI28:444:MPSSPEED
+        on_status: WIRE:LI28:444:MOTR_ON_STS
         retract: WIRE:LI28:444:MOTR_RETRACT
         scan_pulses: WIRE:LI28:444:SCANPULSES
+        scan_status: WIRE:LI28:444:SCANSTAT
         speed: WIRE:LI28:444:MOTR.VELO
         speed_max: WIRE:LI28:444:MOTR.VMAX
         speed_min: WIRE:LI28:444:MOTR.VBAS
@@ -159,8 +163,10 @@ wires:
         motor: WIRE:LI28:744:MOTR
         motor_rbv: WIRE:LI28:744:MOTR.RBV
         mps_speed: WIRE:LI28:744:MPSSPEED
+        on_status: WIRE:LI28:744:MOTR_ON_STS
         retract: WIRE:LI28:744:MOTR_RETRACT
         scan_pulses: WIRE:LI28:744:SCANPULSES
+        scan_status: WIRE:LI28:744:SCANSTAT
         speed: WIRE:LI28:744:MOTR.VELO
         speed_max: WIRE:LI28:744:MOTR.VMAX
         speed_min: WIRE:LI28:744:MOTR.VBAS

--- a/slac_db/package_data/yaml/LTUH.yaml
+++ b/slac_db/package_data/yaml/LTUH.yaml
@@ -2896,8 +2896,10 @@ wires:
         motor: WIRE:LTUH:715:MOTR
         motor_rbv: WIRE:LTUH:715:MOTR.RBV
         mps_speed: WIRE:LTUH:715:MPSSPEED
+        on_status: WIRE:LTUH:715:MOTR_ON_STS
         retract: WIRE:LTUH:715:MOTR_RETRACT
         scan_pulses: WIRE:LTUH:715:SCANPULSES
+        scan_status: WIRE:LTUH:715:SCANSTAT
         speed: WIRE:LTUH:715:MOTR.VELO
         speed_max: WIRE:LTUH:715:MOTR.VMAX
         speed_min: WIRE:LTUH:715:MOTR.VBAS
@@ -2954,8 +2956,10 @@ wires:
         motor: WIRE:LTUH:735:MOTR
         motor_rbv: WIRE:LTUH:735:MOTR.RBV
         mps_speed: WIRE:LTUH:735:MPSSPEED
+        on_status: WIRE:LTUH:735:MOTR_ON_STS
         retract: WIRE:LTUH:735:MOTR_RETRACT
         scan_pulses: WIRE:LTUH:735:SCANPULSES
+        scan_status: WIRE:LTUH:735:SCANSTAT
         speed: WIRE:LTUH:735:MOTR.VELO
         speed_max: WIRE:LTUH:735:MOTR.VMAX
         speed_min: WIRE:LTUH:735:MOTR.VBAS
@@ -3012,8 +3016,10 @@ wires:
         motor: WIRE:LTUH:755:MOTR
         motor_rbv: WIRE:LTUH:755:MOTR.RBV
         mps_speed: WIRE:LTUH:755:MPSSPEED
+        on_status: WIRE:LTUH:755:MOTR_ON_STS
         retract: WIRE:LTUH:755:MOTR_RETRACT
         scan_pulses: WIRE:LTUH:755:SCANPULSES
+        scan_status: WIRE:LTUH:755:SCANSTAT
         speed: WIRE:LTUH:755:MOTR.VELO
         speed_max: WIRE:LTUH:755:MOTR.VMAX
         speed_min: WIRE:LTUH:755:MOTR.VBAS
@@ -3070,8 +3076,10 @@ wires:
         motor: WIRE:LTUH:775:MOTR
         motor_rbv: WIRE:LTUH:775:MOTR.RBV
         mps_speed: WIRE:LTUH:775:MPSSPEED
+        on_status: WIRE:LTUH:775:MOTR_ON_STS
         retract: WIRE:LTUH:775:MOTR_RETRACT
         scan_pulses: WIRE:LTUH:775:SCANPULSES
+        scan_status: WIRE:LTUH:775:SCANSTAT
         speed: WIRE:LTUH:775:MOTR.VELO
         speed_max: WIRE:LTUH:775:MOTR.VMAX
         speed_min: WIRE:LTUH:775:MOTR.VBAS
@@ -3128,8 +3136,10 @@ wires:
         motor: WIRE:LTUH:246:MOTR
         motor_rbv: WIRE:LTUH:246:MOTR.RBV
         mps_speed: WIRE:LTUH:246:MPSSPEED
+        on_status: WIRE:LTUH:246:MOTR_ON_STS
         retract: WIRE:LTUH:246:MOTR_RETRACT
         scan_pulses: WIRE:LTUH:246:SCANPULSES
+        scan_status: WIRE:LTUH:246:SCANSTAT
         speed: WIRE:LTUH:246:MOTR.VELO
         speed_max: WIRE:LTUH:246:MOTR.VMAX
         speed_min: WIRE:LTUH:246:MOTR.VBAS
@@ -3208,8 +3218,10 @@ wires:
         motor: WIRE:LTUH:122:MOTR
         motor_rbv: WIRE:LTUH:122:MOTR.RBV
         mps_speed: WIRE:LTUH:122:MPSSPEED
+        on_status: WIRE:LTUH:122:MOTR_ON_STS
         retract: WIRE:LTUH:122:MOTR_RETRACT
         scan_pulses: WIRE:LTUH:122:SCANPULSES
+        scan_status: WIRE:LTUH:122:SCANSTAT
         speed: WIRE:LTUH:122:MOTR.VELO
         speed_max: WIRE:LTUH:122:MOTR.VMAX
         speed_min: WIRE:LTUH:122:MOTR.VBAS

--- a/slac_db/package_data/yaml/LTUS.yaml
+++ b/slac_db/package_data/yaml/LTUS.yaml
@@ -2787,8 +2787,10 @@ wires:
         motor: WIRE:LTUS:715:MOTR
         motor_rbv: WIRE:LTUS:715:MOTR.RBV
         mps_speed: WIRE:LTUS:715:MPSSPEED
+        on_status: WIRE:LTUS:715:MOTR_ON_STS
         retract: WIRE:LTUS:715:MOTR_RETRACT
         scan_pulses: WIRE:LTUS:715:SCANPULSES
+        scan_status: WIRE:LTUS:715:SCANSTAT
         speed: WIRE:LTUS:715:MOTR.VELO
         speed_max: WIRE:LTUS:715:MOTR.VMAX
         speed_min: WIRE:LTUS:715:MOTR.VBAS
@@ -2858,8 +2860,10 @@ wires:
         motor: WIRE:LTUS:735:MOTR
         motor_rbv: WIRE:LTUS:735:MOTR.RBV
         mps_speed: WIRE:LTUS:735:MPSSPEED
+        on_status: WIRE:LTUS:735:MOTR_ON_STS
         retract: WIRE:LTUS:735:MOTR_RETRACT
         scan_pulses: WIRE:LTUS:735:SCANPULSES
+        scan_status: WIRE:LTUS:735:SCANSTAT
         speed: WIRE:LTUS:735:MOTR.VELO
         speed_max: WIRE:LTUS:735:MOTR.VMAX
         speed_min: WIRE:LTUS:735:MOTR.VBAS
@@ -2929,8 +2933,10 @@ wires:
         motor: WIRE:LTUS:755:MOTR
         motor_rbv: WIRE:LTUS:755:MOTR.RBV
         mps_speed: WIRE:LTUS:755:MPSSPEED
+        on_status: WIRE:LTUS:755:MOTR_ON_STS
         retract: WIRE:LTUS:755:MOTR_RETRACT
         scan_pulses: WIRE:LTUS:755:SCANPULSES
+        scan_status: WIRE:LTUS:755:SCANSTAT
         speed: WIRE:LTUS:755:MOTR.VELO
         speed_max: WIRE:LTUS:755:MOTR.VMAX
         speed_min: WIRE:LTUS:755:MOTR.VBAS
@@ -3000,8 +3006,10 @@ wires:
         motor: WIRE:LTUS:785:MOTR
         motor_rbv: WIRE:LTUS:785:MOTR.RBV
         mps_speed: WIRE:LTUS:785:MPSSPEED
+        on_status: WIRE:LTUS:785:MOTR_ON_STS
         retract: WIRE:LTUS:785:MOTR_RETRACT
         scan_pulses: WIRE:LTUS:785:SCANPULSES
+        scan_status: WIRE:LTUS:785:SCANSTAT
         speed: WIRE:LTUS:785:MOTR.VELO
         speed_max: WIRE:LTUS:785:MOTR.VMAX
         speed_min: WIRE:LTUS:785:MOTR.VBAS

--- a/slac_db/package_data/yaml/SPD.yaml
+++ b/slac_db/package_data/yaml/SPD.yaml
@@ -378,8 +378,10 @@ wires:
         motor: WIRE:SPD:872:MOTR
         motor_rbv: WIRE:SPD:872:MOTR.RBV
         mps_speed: WIRE:SPD:872:MPSSPEED
+        on_status: WIRE:SPD:872:MOTR_ON_STS
         retract: WIRE:SPD:872:MOTR_RETRACT
         scan_pulses: WIRE:SPD:872:SCANPULSES
+        scan_status: WIRE:SPD:872:SCANSTAT
         speed: WIRE:SPD:872:MOTR.VELO
         speed_max: WIRE:SPD:872:MOTR.VMAX
         speed_min: WIRE:SPD:872:MOTR.VBAS


### PR DESCRIPTION
This PR adds two new wire PVs for tracking enabled status during on-the-fly scans.  