### PR TITLE
Added Device Database

### DIFF
--- a/slac_db/create/combined.py
+++ b/slac_db/create/combined.py
@@ -107,12 +107,14 @@ class _Parser():
             beampaths = filter(None, beampaths)
             yield from beampaths
 
-        rv = {}
+        self.areas = set()
+        rv = set()
         for r in slac_db.oracle.get_all_rows():
             beampath_csv = r["beampath"]
             area = r["area"]
-            rv.update({area: b for b in parse_beampaths(beampath_csv)})
-        self.area_map = rv
+            rv = rv.union(set((area, b) for b in parse_beampaths(beampath_csv)))
+            self.areas.add(area)
+        self.area_map = list(rv)
 
     def _device_meta(self):
         def _parse_device():

--- a/slac_db/create/combined.py
+++ b/slac_db/create/combined.py
@@ -21,7 +21,13 @@ class _Parser():
     Expects EPICS Addresses to be 3 units long, e.g. (AAA:BBB:CCC)
     """
     def __init__(self):
+        print("Parsing Area")
+        self._area_map()
+        print("Parsing Device")
+        self._device_meta()
+        print("Parsing Address")
         self._address_map()
+        print("Parsing Accessor")
         self._address_meta()
 
     def _address_meta(self):
@@ -33,6 +39,8 @@ class _Parser():
         """
         def _build():
             for r in slac_db.oracle.get_all_rows():
+                if r["element"] not in self.devices:
+                    continue
                 yield from _meta(
                     r["element"],
                     r["control system name"],
@@ -85,4 +93,39 @@ class _Parser():
             p = name.split(_DELIM)
             return _DELIM.join(p[:3]), _DELIM.join(p[3:])
 
-        self.address_map = dict(_parse(slac_db.directory_service.get_all_addresses()))
+        self.address_map = dict(
+            _parse(
+                slac_db.directory_service.get_all_addresses()
+            )
+        )
+
+    def _area_map(self):
+        def parse_beampaths(beampath_csv):
+            if beampath_csv is None:
+                return []
+            beampaths = beampath_csv.replace(' ', '').split(',')
+            beampaths = filter(None, beampaths)
+            yield from beampaths
+
+        rv = {}
+        for r in slac_db.oracle.get_all_rows():
+            beampath_csv = r["beampath"]
+            area = r["area"]
+            rv.update({area: b for b in parse_beampaths(beampath_csv)})
+        self.area_map = rv
+
+    def _device_meta(self):
+        def _parse_device():
+            for r in slac_db.oracle.get_all_rows():
+                yv = {
+                    "device_name": r["element"],
+                    "area": r["area"],
+                    "device_type": r["keyword"],
+                    "cs_name": r["control system name"]                    
+                }
+                if None in yv.values() or ":" in r["element"]:
+                    continue
+                self.devices.add(r["element"])
+                yield yv
+        self.devices = set()
+        self.device_meta = [device for device in _parse_device()]

--- a/slac_db/device.py
+++ b/slac_db/device.py
@@ -5,6 +5,57 @@ import sqlalchemy
 
 _meta = None
 
+def get_areas(beampath=None):
+    """ Get all areas in a beampath.
+
+    Args:
+        beampath (str): Beampath name
+
+    Out:
+        list of areas (str) in alphabetical order.
+    """
+    with _session() as s:
+        selection = (
+            sqlalchemy.select(s.t.beampaths)
+            .where(s.t.beampaths.c["beampath"] == beampath)
+        )
+        return sorted([a["area"] for a in s.select(selection)])
+
+def get_beampath(beampath=None, device_type=None):
+    """ Get all devices in a beampath, optionally by type.
+
+    Args:
+        beampath (str): Beampath name
+        device_type (str) optional: Device type in Oracle
+
+    Out:
+        List of devices in alphabetical order.
+    """
+    with _session() as s:
+        selection = sqlalchemy.select(s.t.devices).join(s.t.beampaths, s.t.beampaths.c.area == s.t.devices.c.area)
+        selection = selection.where(s.t.beampaths.c["beampath"] == beampath)
+        if device_type is not None:
+            selection = selection.where(s.t.devices.c["device_type"] == device_type)
+        return sorted([d["device_name"] for d in s.select(selection)])
+
+def get_device(area=None, device_type=None):
+    """ Get all devices in an area of a type.
+
+    Args:
+        area (str) optional: Area name
+        device_type (str) optional: Device type in Oracle
+
+    Out:
+        List of devices in alphabetical order.
+    """
+    with _session() as s:
+        selection = sqlalchemy.select(s.t.devices)
+        if area is not None:
+            selection = selection.where(s.t.devices.c["area"] == area)
+        if device_type is not None:
+            selection = selection.where(s.t.devices.c["device_type"] == device_type)
+        return sorted([d["device_name"] for d in s.select(selection)])
+
 def get_all_accessors(device):
     """Get all accessors from a device.
     An accessor is a developer friendly name for a PV
@@ -65,9 +116,9 @@ class _Inserter():
         self.parser = parser
         with _session() as s:
             print("Creating Beampath")
-            self.create_beampath_db(s)
+            self.create_areas_db(s)
             print("Creating Area")
-            self.create_area_db(s)
+            self.create_beampaths_db(s)
             print("Creating device")
             self.create_device_db(s)
             print("Creating Address")
@@ -77,15 +128,17 @@ class _Inserter():
 
     def create_device_db(self, s):
         for d in self.parser.device_meta:
+            if d["area"] not in self.parser.areas:
+                continue
             s.insert("devices", **d)
 
-    def create_area_db(self, s):
-        for a, b in self.parser.area_map.items():
-            s.insert("areas", area=a, beampath=b)
+    def create_beampaths_db(self, s):
+        for a, b in self.parser.area_map:
+            s.insert("beampaths", area=a, beampath=b)
 
-    def create_beampath_db(self, s):
-        for b in set(self.parser.area_map.values()):
-            s.insert("beampaths", beampath=b)
+    def create_areas_db(self, s):
+        for a in self.parser.areas:
+            s.insert("areas", area=a)
 
     def create_address_db(self, s):
         for p in self.parser.device_address_meta:
@@ -120,16 +173,16 @@ def _init_db(location=None):
         location = _device_db_location()
     uri = _db_type_prefix(location)
     schema = {
-        "beampaths": {
-            "beampath": "str 64 primary_key",
-        },
         "areas": {
             "area": "str 64 primary_key",
-            "beampath": "str 64 primary_key foreign"
+        },
+        "beampaths": {
+            "area": "str 64 primary_key foreign",
+            "beampath": "str 64 primary_key"
         },
         "devices": {
             "device_name": "str 64 primary_key",
-            "area": "str 64",
+            "area": "str 64 foreign",
             "device_type": "str 64",
             "cs_name": "str 64"
         },

--- a/slac_db/device.py
+++ b/slac_db/device.py
@@ -64,8 +64,28 @@ class _Inserter():
     def __init__(self, parser):
         self.parser = parser
         with _session() as s:
+            print("Creating Beampath")
+            self.create_beampath_db(s)
+            print("Creating Area")
+            self.create_area_db(s)
+            print("Creating device")
+            self.create_device_db(s)
+            print("Creating Address")
             self.create_address_db(s)
+            print("Creating Accessor")
             self.create_accessor_db(s)
+
+    def create_device_db(self, s):
+        for d in self.parser.device_meta:
+            s.insert("devices", **d)
+
+    def create_area_db(self, s):
+        for a, b in self.parser.area_map.items():
+            s.insert("areas", area=a, beampath=b)
+
+    def create_beampath_db(self, s):
+        for b in set(self.parser.area_map.values()):
+            s.insert("beampaths", beampath=b)
 
     def create_address_db(self, s):
         for p in self.parser.device_address_meta:
@@ -100,14 +120,27 @@ def _init_db(location=None):
         location = _device_db_location()
     uri = _db_type_prefix(location)
     schema = {
-        "accessors": {
+        "beampaths": {
+            "beampath": "str 64 primary_key",
+        },
+        "areas": {
+            "area": "str 64 primary_key",
+            "beampath": "str 64 primary_key foreign"
+        },
+        "devices": {
             "device_name": "str 64 primary_key",
-            "accessor_name": "str 64 primary_key",
-            "cs_address": "str 64",
+            "area": "str 64",
+            "device_type": "str 64",
+            "cs_name": "str 64"
         },
         "addresses": {
-            "device_name": "str 64 primary_key",
+            "device_name": "str 64 primary_key foreign",
             "cs_address": "str 64 primary_key",
+        },
+        "accessors": {
+            "device_name": "str 64 primary_key foreign",
+            "accessor_name": "str 64 primary_key",
+            "cs_address": "str 64",
         },
     }
     _meta = pykern.sql_db.Meta(

--- a/slac_db/device.py
+++ b/slac_db/device.py
@@ -38,7 +38,7 @@ def get_beampath(beampath=None, device_type=None):
             selection = selection.where(s.t.devices.c["device_type"] == device_type)
         return sorted([d["device_name"] for d in s.select(selection)])
 
-def get_device(area=None, device_type=None):
+def get_devices(area=None, device_type=None):
     """ Get all devices in an area of a type.
 
     Args:

--- a/slac_db/package_data/device.sqlite3
+++ b/slac_db/package_data/device.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:882232cd8de8d832def08c8d1fc7d62649ed85d664b61e5b520f9af064a66dfc
-size 484900864
+oid sha256:fb5c809e5a8cbc4042439e94963d63feccd39fd3d4a342a2441e04f3ab507d0f
+size 484995072

--- a/slac_db/package_data/device.sqlite3
+++ b/slac_db/package_data/device.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89b4e61a15d8671700e5cfb0f68e372cc458e484d59f83510cd9f6df6ecbe55b
-size 484782080
+oid sha256:882232cd8de8d832def08c8d1fc7d62649ed85d664b61e5b520f9af064a66dfc
+size 484900864

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -13,3 +13,8 @@ class test_device(unittest.TestCase):
             test_data_path / "OTRDG02_names.txt"
         ).splitlines()
         self.assertEqual(len(value), len(expected))
+
+    def test_get_device(self):
+        value = slac_db.device.get_device(area="DIAG0", device_type="PROF")
+        expected = ["OTRDG02", "OTRDG04"]
+        self.assertEqual(value, expected)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,6 +15,6 @@ class test_device(unittest.TestCase):
         self.assertEqual(len(value), len(expected))
 
     def test_get_device(self):
-        value = slac_db.device.get_device(area="DIAG0", device_type="PROF")
+        value = slac_db.device.get_devices(area="DIAG0", device_type="PROF")
         expected = ["OTRDG02", "OTRDG04"]
         self.assertEqual(value, expected)


### PR DESCRIPTION
This new database maps areas to beampaths, areas to devices, and devices to accessors + addresses. Introduces `get_areas`, which collects areas by beampath, `get_beampath`, which collects devices by beampath, and `get_devices` which collects devices by device type and area.

Next step after this include:
- metadata fields, particularly for Z position.
- Filtering methods for Oracle data.