### PR TITLE
Refactor TMITLOSS metadata and add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/slac_db/package_data/device.sqlite3
+++ b/slac_db/package_data/device.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc87da68d238b5b058a45936d1ab0640d961a882380a13f87cd86cc88f97dd33
-size 331833344
+oid sha256:e976e0f520705253fe75ddbbb11c6734effaf271db80354f536255dead8d734c
+size 331829248

--- a/slac_db/package_data/wire_metadata.yaml
+++ b/slac_db/package_data/wire_metadata.yaml
@@ -109,14 +109,14 @@ WS0H04:
     - TMITLOSS:HTR
   default_detector: TMITLOSS:HTR
   bpms_before_wire:
-    - BPMS:GUNB:925
-    - BPMS:HTR:120
-    - BPMS:HTR:320
+    - BPM2B
+    - BPM0H01
+    - BPM0H04
   bpms_after_wire:
-    - BPMS:HTR:760
-    - BPMS:HTR:830
-    - BPMS:HTR:860
-    - BPMS:HTR:960
+    - BPMH2
+    - BPMHD01
+    - BPMHD02
+    - BPMHD03
   wire_type: fast
 
 WSDG01:
@@ -124,19 +124,20 @@ WSDG01:
     - SBLM01A:DIAG0
     - LBLM01A:HTR
     - LBLM01B:HTR
+    - TMITLOSS:DIAG0
   default_detector: LBLM01A:HTR
   bpms_before_wire:
-    - BPMS:DIAG0:190
-    - BPMS:DIAG0:210
-    - BPMS:DIAG0:230
-    - BPMS:DIAG0:270
-    - BPMS:DIAG0:285
-    - BPMS:DIAG0:330
-    - BPMS:DIAG0:370
-    - BPMS:DIAG0:390
+    - BPMDG001
+    - BPMDG002
+    - BPMDG003
+    - BPMDG004
+    - BPMDG005
+    - BPMDG0RF
+    - BPMDG008
+    - BPMDG009
   bpms_after_wire:
-    - BPMS:DIAG0:470
-    - BPMS:DIAG0:520
+    - BPMDG011
+    - BPMDG012
   wire_type: slow
 
 WSC104:
@@ -146,21 +147,21 @@ WSC104:
     - TMITLOSS:COL1
   default_detector: TMITLOSS:COL1
   bpms_before_wire:
-    - BPMS:BC1B:125
-    - BPMS:BC1B:440
-    - BPMS:COL1:120
-    - BPMS:COL1:260
-    - BPMS:COL1:280
-    - BPMS:COL1:320
+    - BPM1C01
+    - BPM11B
+    - BPMC101
+    - BPMC102
+    - BPMC103
+    - BPMC104
   bpms_after_wire:
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPD:420
-    - BPMS:SPD:525
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSPS
+    - BPMSP1D
   wire_type: fast
 
 WSC106:
@@ -170,21 +171,21 @@ WSC106:
     - TMITLOSS:COL1
   default_detector: TMITLOSS:COL1
   bpms_before_wire:
-    - BPMS:BC1B:125
-    - BPMS:BC1B:440
-    - BPMS:COL1:120
-    - BPMS:COL1:260
-    - BPMS:COL1:280
-    - BPMS:COL1:320
+    - BPM1C01
+    - BPM11B
+    - BPMC101
+    - BPMC102
+    - BPMC103
+    - BPMC104
   bpms_after_wire:
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPD:420
-    - BPMS:SPD:525
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSPS
+    - BPMSP1D
   wire_type: fast
 
 WSC108:
@@ -194,21 +195,21 @@ WSC108:
     - TMITLOSS:COL1
   default_detector: TMITLOSS:COL1
   bpms_before_wire:
-    - BPMS:BC1B:125
-    - BPMS:BC1B:440
-    - BPMS:COL1:120
-    - BPMS:COL1:260
-    - BPMS:COL1:280
-    - BPMS:COL1:320
+    - BPM1C01
+    - BPM11B
+    - BPMC101
+    - BPMC102
+    - BPMC103
+    - BPMC104
   bpms_after_wire:
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPD:420
-    - BPMS:SPD:525
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSPS
+    - BPMSP1D
   wire_type: fast
 
 WSC110:
@@ -218,21 +219,21 @@ WSC110:
     - TMITLOSS:COL1
   default_detector: TMITLOSS:COL1
   bpms_before_wire:
-    - BPMS:BC1B:125
-    - BPMS:BC1B:440
-    - BPMS:COL1:120
-    - BPMS:COL1:260
-    - BPMS:COL1:280
-    - BPMS:COL1:320
+    - BPM1C01
+    - BPM11B
+    - BPMC101
+    - BPMC102
+    - BPMC103
+    - BPMC104
   bpms_after_wire:
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPD:420
-    - BPMS:SPD:525
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSPS
+    - BPMSP1D
   wire_type: fast
 
 WSEMIT2:
@@ -242,17 +243,17 @@ WSEMIT2:
     - TMITLOSS:EMIT2
   default_detector: TMITLOSS:EMIT2
   bpms_before_wire:
-    - BPMS:BC2B:150
-    - BPMS:BC2B:530
-    - BPMS:EMIT2:150
-    - BPMS:EMIT2:300
+    - BPM2C01
+    - BPM21B
+    - BPME201
+    - BPME202
   bpms_after_wire:
-    - BPMS:SPS:780
-    - BPMS:SPS:830
-    - BPMS:SPS:840
-    - BPMS:SLTS:150
-    - BPMS:SLTS:430
-    - BPMS:SLTS:460
+    - BPMSP7S
+    - BPMSP8S
+    - BPMSP9S
+    - BPMBP36
+    - BPMBP31
+    - BPMBP32
   wire_type: fast
 
 WSBP1:
@@ -263,35 +264,35 @@ WSBP1:
     - TMITLOSS:BYP
   default_detector: TMITLOSS:BYP
   bpms_before_wire:
-    - BPMS:L3B:3583
-    - BPMS:EXT:351
-    - BPMS:EXT:748
-    - BPMS:DOG:120
-    - BPMS:DOG:135
-    - BPMS:DOG:150
-    - BPMS:DOG:200
+    - CMB35
+    - BPMX01
+    - BPMX02
+    - BPMDOG1
+    - BPMDOG2
+    - BPMDOG3
+    - BPMDOG6
     - BPMS:DOG:215
     - BPMS:DOG:230
-    - BPMS:DOG:280
-    - BPMS:DOG:335
-    - BPMS:DOG:355
-    - BPMS:DOG:405
+    - BPML2P
+    - BPML3P
+    - BPML4P
+    - BPML5P
   bpms_after_wire:
-    - BPMS:BPN23:400
-    - BPMS:BPN24:400
-    - BPMS:BPN25:400
-    - BPMS:BPN26:400
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPD:420
-    - BPMS:SPD:525
-    - BPMS:SPD:570
-    - BPMS:SPD:700
-    - BPMS:SPD:955
+    - BPMBP23
+    - BPMBP24
+    - BPMBP25
+    - BPMBP26
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSPS
+    - BPMSP1D
+    - BPMDAS
+    - BPMSP2D
+    - BPMSP3D
   wire_type: fast
 
 WSBP2:
@@ -302,35 +303,35 @@ WSBP2:
     - TMITLOSS:BYP
   default_detector: TMITLOSS:BYP
   bpms_before_wire:
-    - BPMS:L3B:3583
-    - BPMS:EXT:351
-    - BPMS:EXT:748
-    - BPMS:DOG:120
-    - BPMS:DOG:135
-    - BPMS:DOG:150
-    - BPMS:DOG:200
-    - BPMS:DOG:215
-    - BPMS:DOG:230
-    - BPMS:DOG:280
-    - BPMS:DOG:335
-    - BPMS:DOG:355
-    - BPMS:DOG:405
+    - CMB35
+    - BPMX01
+    - BPMX02
+    - BPMDOG1
+    - BPMDOG2
+    - BPMDOG3
+    - BPMDOG6
+    - BPMDOG7
+    - BPMDOG8
+    - BPML2P
+    - BPML3P
+    - BPML4P
+    - BPML5P
   bpms_after_wire:
-    - BPMS:BPN23:400
-    - BPMS:BPN24:400
-    - BPMS:BPN25:400
-    - BPMS:BPN26:400
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPD:420
-    - BPMS:SPD:525
-    - BPMS:SPD:570
-    - BPMS:SPD:700
-    - BPMS:SPD:955
+    - BPMBP23
+    - BPMBP24
+    - BPMBP25
+    - BPMBP26
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSPS
+    - BPMSP1D
+    - BPMDAS
+    - BPMSP2D
+    - BPMSP3D
   wire_type: fast
 
 WSBP3:
@@ -341,35 +342,35 @@ WSBP3:
     - TMITLOSS:BYP
   default_detector: TMITLOSS:BYP
   bpms_before_wire:
-    - BPMS:L3B:3583
-    - BPMS:EXT:351
-    - BPMS:EXT:748
-    - BPMS:DOG:120
-    - BPMS:DOG:135
-    - BPMS:DOG:150
-    - BPMS:DOG:200
-    - BPMS:DOG:215
-    - BPMS:DOG:230
-    - BPMS:DOG:280
-    - BPMS:DOG:335
-    - BPMS:DOG:355
-    - BPMS:DOG:405
+    - CMB35
+    - BPMX01
+    - BPMX02
+    - BPMDOG1
+    - BPMDOG2
+    - BPMDOG3
+    - BPMDOG6
+    - BPMDOG7
+    - BPMDOG8
+    - BPML2P
+    - BPML3P
+    - BPML4P
+    - BPML5P
   bpms_after_wire:
-    - BPMS:BPN23:400
-    - BPMS:BPN24:400
-    - BPMS:BPN25:400
-    - BPMS:BPN26:400
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPD:420
-    - BPMS:SPD:525
-    - BPMS:SPD:570
-    - BPMS:SPD:700
-    - BPMS:SPD:955
+    - BPMBP23
+    - BPMBP24
+    - BPMBP25
+    - BPMBP26
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSPS
+    - BPMSP1D
+    - BPMDAS
+    - BPMSP2D
+    - BPMSP3D
   wire_type: fast
 
 WSBP4:
@@ -380,35 +381,35 @@ WSBP4:
     - TMITLOSS:BYP
   default_detector: TMITLOSS:BYP
   bpms_before_wire:
-    - BPMS:L3B:3583
-    - BPMS:EXT:351
-    - BPMS:EXT:748
-    - BPMS:DOG:120
-    - BPMS:DOG:135
-    - BPMS:DOG:150
-    - BPMS:DOG:200
-    - BPMS:DOG:215
-    - BPMS:DOG:230
-    - BPMS:DOG:280
-    - BPMS:DOG:335
-    - BPMS:DOG:355
-    - BPMS:DOG:405
+    - CMB35
+    - BPMX01
+    - BPMX02
+    - BPMDOG1
+    - BPMDOG2
+    - BPMDOG3
+    - BPMDOG6
+    - BPMDOG7
+    - BPMDOG8
+    - BPML2P
+    - BPML3P
+    - BPML4P
+    - BPML5P
   bpms_after_wire:
-    - BPMS:BPN23:400
-    - BPMS:BPN24:400
-    - BPMS:BPN25:400
-    - BPMS:BPN26:400
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPD:420
-    - BPMS:SPD:525
-    - BPMS:SPD:570
-    - BPMS:SPD:700
-    - BPMS:SPD:955
+    - BPMBP23
+    - BPMBP24
+    - BPMBP25
+    - BPMBP26
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSPS
+    - BPMSP1D
+    - BPMDAS
+    - BPMSP2D
+    - BPMSP3D
   wire_type: fast
 
 WSSP1D:
@@ -416,16 +417,16 @@ WSSP1D:
     - LBLM22A:SPS
   default_detector: LBLM22A:SPS
   bpms_before_wire:
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPD:420
-    - BPMS:SPD:525
-    - BPMS:SPD:570
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSPS
+    - BPMSP1D
+    - BPMDAS
   bpms_after_wire:
-    - BPMS:SPD:700
-    - BPMS:SPD:955
-    - BPMS:SLTD:625
+    - BPMSP2D
+    - BPMSP3D
+    - BPMSP4D
   wire_type: fast
 
 WS31:
@@ -494,25 +495,25 @@ WS31B:
     - TMITLOSS:LTUS
   default_detector: TMITLOSS:LTUS
   bpms_before_wire:
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPS:572
-    - BPMS:SPS:580
-    - BPMS:SPS:640
-    - BPMS:SPS:710
-    - BPMS:SPS:770
-    - BPMS:SPS:780
-    - BPMS:SPS:830
-    - BPMS:SPS:840
-    - BPMS:SLTS:150
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSP1S
+    - BPMSP2S
+    - BPMSP3S
+    - BPMSP5S
+    - BPMSP6S
+    - BPMSP7S
+    - BPMSP8S
+    - BPMSP9S
+    - BPMBP36
   bpms_after_wire:
-    - BPMS:DMPS:381
-    - BPMS:DMPS:502
-    - BPMS:DMPS:693
+    - BPMUE2B
+    - BPMQDB
+    - BPMDDB
   wire_type: fast
 
 WS32B:
@@ -521,25 +522,25 @@ WS32B:
     - TMITLOSS:LTUS
   default_detector: TMITLOSS:LTUS
   bpms_before_wire:
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPS:572
-    - BPMS:SPS:580
-    - BPMS:SPS:640
-    - BPMS:SPS:710
-    - BPMS:SPS:770
-    - BPMS:SPS:780
-    - BPMS:SPS:830
-    - BPMS:SPS:840
-    - BPMS:SLTS:150
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSP1S
+    - BPMSP2S
+    - BPMSP3S
+    - BPMSP5S
+    - BPMSP6S
+    - BPMSP7S
+    - BPMSP8S
+    - BPMSP9S
+    - BPMBP36
   bpms_after_wire:
-    - BPMS:DMPS:381
-    - BPMS:DMPS:502
-    - BPMS:DMPS:693
+    - BPMUE2B
+    - BPMQDB
+    - BPMDDB
   wire_type: fast
 
 WS33B:
@@ -548,25 +549,25 @@ WS33B:
     - TMITLOSS:LTUS
   default_detector: TMITLOSS:LTUS
   bpms_before_wire:
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPS:572
-    - BPMS:SPS:580
-    - BPMS:SPS:640
-    - BPMS:SPS:710
-    - BPMS:SPS:770
-    - BPMS:SPS:780
-    - BPMS:SPS:830
-    - BPMS:SPS:840
-    - BPMS:SLTS:150
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSP1S
+    - BPMSP2S
+    - BPMSP3S
+    - BPMSP5S
+    - BPMSP6S
+    - BPMSP7S
+    - BPMSP8S
+    - BPMSP9S
+    - BPMBP36
   bpms_after_wire:
-    - BPMS:DMPS:381
-    - BPMS:DMPS:502
-    - BPMS:DMPS:693
+    - BPMUE2B
+    - BPMQDB
+    - BPMDDB
   wire_type: fast
 
 WS34B:
@@ -575,23 +576,23 @@ WS34B:
     - TMITLOSS:LTUS
   default_detector: TMITLOSS:LTUS
   bpms_before_wire:
-    - BPMS:BPN27:400
-    - BPMS:BPN28:200
-    - BPMS:BPN28:400
-    - BPMS:SPD:135
-    - BPMS:SPD:255
-    - BPMS:SPD:340
-    - BPMS:SPS:572
-    - BPMS:SPS:580
-    - BPMS:SPS:640
-    - BPMS:SPS:710
-    - BPMS:SPS:770
-    - BPMS:SPS:780
-    - BPMS:SPS:830
-    - BPMS:SPS:840
-    - BPMS:SLTS:150
+    - BPMBP27
+    - BPMBP35
+    - BPMBP28
+    - BPMSPH
+    - BPMSP1
+    - BPMSP2
+    - BPMSP1S
+    - BPMSP2S
+    - BPMSP3S
+    - BPMSP5S
+    - BPMSP6S
+    - BPMSP7S
+    - BPMSP8S
+    - BPMSP9S
+    - BPMBP36
   bpms_after_wire:
-    - BPMS:DMPS:381
-    - BPMS:DMPS:502
-    - BPMS:DMPS:693
+    - BPMUE2B
+    - BPMQDB
+    - BPMDDB
   wire_type: fast

--- a/slac_db/package_data/wire_metadata.yaml
+++ b/slac_db/package_data/wire_metadata.yaml
@@ -75,7 +75,19 @@ WS27644:
     - PMT29150:LI29
     - PMT756:LTUH
     - PMT820:LTUH
+    - TMITLOSS:L3
   default_detector: PMT29150:LI29
+  tmitloss:
+    upstream:
+      - BPM27301
+      - BPM27401
+      - BPM27501
+      - BPM27601
+    downstream:
+      - BPM30501
+      - BPM30601
+      - BPM30701
+      - BPM30801
   wire_type: fast
 
 WS28144:
@@ -83,7 +95,19 @@ WS28144:
     - PMT29150:LI29
     - PMT756:LTUH
     - PMT820:LTUH
+    - TMITLOSS:L3
   default_detector: PMT29150:LI29
+  tmitloss:
+    upstream:
+      - BPM27301
+      - BPM27401
+      - BPM27501
+      - BPM27601
+    downstream:
+      - BPM30501
+      - BPM30601
+      - BPM30701
+      - BPM30801
   wire_type: fast
 
 WS28444:
@@ -91,7 +115,19 @@ WS28444:
     - PMT29150:LI29
     - PMT756:LTUH
     - PMT820:LTUH
+    - TMITLOSS:L3
   default_detector: PMT29150:LI29
+  tmitloss:
+    upstream:
+      - BPM27301
+      - BPM27401
+      - BPM27501
+      - BPM27601
+    downstream:
+      - BPM30501
+      - BPM30601
+      - BPM30701
+      - BPM30801
   wire_type: fast
 
 WS28744:
@@ -99,7 +135,19 @@ WS28744:
     - PMT29150:LI29
     - PMT756:LTUH
     - PMT820:LTUH
+    - TMITLOSS:L3
   default_detector: PMT29150:LI29
+  tmitloss:
+    upstream:
+      - BPM27301
+      - BPM27401
+      - BPM27501
+      - BPM27601
+    downstream:
+      - BPM30501
+      - BPM30601
+      - BPM30701
+      - BPM30801
   wire_type: fast
 
 WS0H04:

--- a/slac_db/package_data/wire_metadata.yaml
+++ b/slac_db/package_data/wire_metadata.yaml
@@ -108,15 +108,16 @@ WS0H04:
     - LBLM01B:HTR
     - TMITLOSS:HTR
   default_detector: TMITLOSS:HTR
-  bpms_before_wire:
-    - BPM2B
-    - BPM0H01
-    - BPM0H04
-  bpms_after_wire:
-    - BPMH2
-    - BPMHD01
-    - BPMHD02
-    - BPMHD03
+  tmitloss:
+    upstream:
+      - BPM2B
+      - BPM0H01
+      - BPM0H04
+    downstream:
+      - BPMH2
+      - BPMHD01
+      - BPMHD02
+      - BPMHD03
   wire_type: fast
 
 WSDG01:
@@ -126,18 +127,19 @@ WSDG01:
     - LBLM01B:HTR
     - TMITLOSS:DIAG0
   default_detector: LBLM01A:HTR
-  bpms_before_wire:
-    - BPMDG001
-    - BPMDG002
-    - BPMDG003
-    - BPMDG004
-    - BPMDG005
-    - BPMDG0RF
-    - BPMDG008
-    - BPMDG009
-  bpms_after_wire:
-    - BPMDG011
-    - BPMDG012
+  tmitloss:
+    upstream:
+      - BPMDG001
+      - BPMDG002
+      - BPMDG003
+      - BPMDG004
+      - BPMDG005
+      - BPMDG0RF
+      - BPMDG008
+      - BPMDG009
+    downstream:
+      - BPMDG011
+      - BPMDG012
   wire_type: slow
 
 WSC104:
@@ -146,22 +148,23 @@ WSC104:
     - LBLM04A:L2B
     - TMITLOSS:COL1
   default_detector: TMITLOSS:COL1
-  bpms_before_wire:
-    - BPM1C01
-    - BPM11B
-    - BPMC101
-    - BPMC102
-    - BPMC103
-    - BPMC104
-  bpms_after_wire:
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSPS
-    - BPMSP1D
+  tmitloss:
+    upstream:
+      - BPM1C01
+      - BPM11B
+      - BPMC101
+      - BPMC102
+      - BPMC103
+      - BPMC104
+    downstream:
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSPS
+      - BPMSP1D
   wire_type: fast
 
 WSC106:
@@ -170,22 +173,23 @@ WSC106:
     - LBLM04A:L2B
     - TMITLOSS:COL1
   default_detector: TMITLOSS:COL1
-  bpms_before_wire:
-    - BPM1C01
-    - BPM11B
-    - BPMC101
-    - BPMC102
-    - BPMC103
-    - BPMC104
-  bpms_after_wire:
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSPS
-    - BPMSP1D
+  tmitloss:
+    upstream:
+      - BPM1C01
+      - BPM11B
+      - BPMC101
+      - BPMC102
+      - BPMC103
+      - BPMC104
+    downstream:
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSPS
+      - BPMSP1D
   wire_type: fast
 
 WSC108:
@@ -194,22 +198,23 @@ WSC108:
     - LBLM04A:L2B
     - TMITLOSS:COL1
   default_detector: TMITLOSS:COL1
-  bpms_before_wire:
-    - BPM1C01
-    - BPM11B
-    - BPMC101
-    - BPMC102
-    - BPMC103
-    - BPMC104
-  bpms_after_wire:
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSPS
-    - BPMSP1D
+  tmitloss:
+    upstream:
+      - BPM1C01
+      - BPM11B
+      - BPMC101
+      - BPMC102
+      - BPMC103
+      - BPMC104
+    downstream:
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSPS
+      - BPMSP1D
   wire_type: fast
 
 WSC110:
@@ -218,22 +223,23 @@ WSC110:
     - LBLM04A:L2B
     - TMITLOSS:COL1
   default_detector: TMITLOSS:COL1
-  bpms_before_wire:
-    - BPM1C01
-    - BPM11B
-    - BPMC101
-    - BPMC102
-    - BPMC103
-    - BPMC104
-  bpms_after_wire:
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSPS
-    - BPMSP1D
+  tmitloss:
+    upstream:
+      - BPM1C01
+      - BPM11B
+      - BPMC101
+      - BPMC102
+      - BPMC103
+      - BPMC104
+    downstream:
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSPS
+      - BPMSP1D
   wire_type: fast
 
 WSEMIT2:
@@ -242,18 +248,19 @@ WSEMIT2:
     - LBLM07A:L3B
     - TMITLOSS:EMIT2
   default_detector: TMITLOSS:EMIT2
-  bpms_before_wire:
-    - BPM2C01
-    - BPM21B
-    - BPME201
-    - BPME202
-  bpms_after_wire:
-    - BPMSP7S
-    - BPMSP8S
-    - BPMSP9S
-    - BPMBP36
-    - BPMBP31
-    - BPMBP32
+  tmitloss:
+    upstream:
+      - BPM2C01
+      - BPM21B
+      - BPME201
+      - BPME202
+    downstream:
+      - BPMSP7S
+      - BPMSP8S
+      - BPMSP9S
+      - BPMBP36
+      - BPMBP31
+      - BPMBP32
   wire_type: fast
 
 WSBP1:
@@ -263,36 +270,37 @@ WSBP1:
     - LBLM11A_3:BYP
     - TMITLOSS:BYP
   default_detector: TMITLOSS:BYP
-  bpms_before_wire:
-    - CMB35
-    - BPMX01
-    - BPMX02
-    - BPMDOG1
-    - BPMDOG2
-    - BPMDOG3
-    - BPMDOG6
-    - BPMS:DOG:215
-    - BPMS:DOG:230
-    - BPML2P
-    - BPML3P
-    - BPML4P
-    - BPML5P
-  bpms_after_wire:
-    - BPMBP23
-    - BPMBP24
-    - BPMBP25
-    - BPMBP26
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSPS
-    - BPMSP1D
-    - BPMDAS
-    - BPMSP2D
-    - BPMSP3D
+  tmitloss:
+    upstream:
+      - CMB35
+      - BPMX01
+      - BPMX02
+      - BPMDOG1
+      - BPMDOG2
+      - BPMDOG3
+      - BPMDOG6
+      - BPMS:DOG:215
+      - BPMS:DOG:230
+      - BPML2P
+      - BPML3P
+      - BPML4P
+      - BPML5P
+    downstream:
+      - BPMBP23
+      - BPMBP24
+      - BPMBP25
+      - BPMBP26
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSPS
+      - BPMSP1D
+      - BPMDAS
+      - BPMSP2D
+      - BPMSP3D
   wire_type: fast
 
 WSBP2:
@@ -302,36 +310,37 @@ WSBP2:
     - LBLM11A_3:BYP
     - TMITLOSS:BYP
   default_detector: TMITLOSS:BYP
-  bpms_before_wire:
-    - CMB35
-    - BPMX01
-    - BPMX02
-    - BPMDOG1
-    - BPMDOG2
-    - BPMDOG3
-    - BPMDOG6
-    - BPMDOG7
-    - BPMDOG8
-    - BPML2P
-    - BPML3P
-    - BPML4P
-    - BPML5P
-  bpms_after_wire:
-    - BPMBP23
-    - BPMBP24
-    - BPMBP25
-    - BPMBP26
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSPS
-    - BPMSP1D
-    - BPMDAS
-    - BPMSP2D
-    - BPMSP3D
+  tmitloss:
+    upstream:
+      - CMB35
+      - BPMX01
+      - BPMX02
+      - BPMDOG1
+      - BPMDOG2
+      - BPMDOG3
+      - BPMDOG6
+      - BPMDOG7
+      - BPMDOG8
+      - BPML2P
+      - BPML3P
+      - BPML4P
+      - BPML5P
+    downstream:
+      - BPMBP23
+      - BPMBP24
+      - BPMBP25
+      - BPMBP26
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSPS
+      - BPMSP1D
+      - BPMDAS
+      - BPMSP2D
+      - BPMSP3D
   wire_type: fast
 
 WSBP3:
@@ -341,36 +350,37 @@ WSBP3:
     - LBLM11A_3:BYP
     - TMITLOSS:BYP
   default_detector: TMITLOSS:BYP
-  bpms_before_wire:
-    - CMB35
-    - BPMX01
-    - BPMX02
-    - BPMDOG1
-    - BPMDOG2
-    - BPMDOG3
-    - BPMDOG6
-    - BPMDOG7
-    - BPMDOG8
-    - BPML2P
-    - BPML3P
-    - BPML4P
-    - BPML5P
-  bpms_after_wire:
-    - BPMBP23
-    - BPMBP24
-    - BPMBP25
-    - BPMBP26
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSPS
-    - BPMSP1D
-    - BPMDAS
-    - BPMSP2D
-    - BPMSP3D
+  tmitloss:
+    upstream:
+      - CMB35
+      - BPMX01
+      - BPMX02
+      - BPMDOG1
+      - BPMDOG2
+      - BPMDOG3
+      - BPMDOG6
+      - BPMDOG7
+      - BPMDOG8
+      - BPML2P
+      - BPML3P
+      - BPML4P
+      - BPML5P
+    downstream:
+      - BPMBP23
+      - BPMBP24
+      - BPMBP25
+      - BPMBP26
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSPS
+      - BPMSP1D
+      - BPMDAS
+      - BPMSP2D
+      - BPMSP3D
   wire_type: fast
 
 WSBP4:
@@ -380,53 +390,55 @@ WSBP4:
     - LBLM11A_3:BYP
     - TMITLOSS:BYP
   default_detector: TMITLOSS:BYP
-  bpms_before_wire:
-    - CMB35
-    - BPMX01
-    - BPMX02
-    - BPMDOG1
-    - BPMDOG2
-    - BPMDOG3
-    - BPMDOG6
-    - BPMDOG7
-    - BPMDOG8
-    - BPML2P
-    - BPML3P
-    - BPML4P
-    - BPML5P
-  bpms_after_wire:
-    - BPMBP23
-    - BPMBP24
-    - BPMBP25
-    - BPMBP26
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSPS
-    - BPMSP1D
-    - BPMDAS
-    - BPMSP2D
-    - BPMSP3D
+  tmitloss:
+    upstream:
+      - CMB35
+      - BPMX01
+      - BPMX02
+      - BPMDOG1
+      - BPMDOG2
+      - BPMDOG3
+      - BPMDOG6
+      - BPMDOG7
+      - BPMDOG8
+      - BPML2P
+      - BPML3P
+      - BPML4P
+      - BPML5P
+    downstream:
+      - BPMBP23
+      - BPMBP24
+      - BPMBP25
+      - BPMBP26
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSPS
+      - BPMSP1D
+      - BPMDAS
+      - BPMSP2D
+      - BPMSP3D
   wire_type: fast
 
 WSSP1D:
   detectors:
     - LBLM22A:SPS
   default_detector: LBLM22A:SPS
-  bpms_before_wire:
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSPS
-    - BPMSP1D
-    - BPMDAS
-  bpms_after_wire:
-    - BPMSP2D
-    - BPMSP3D
-    - BPMSP4D
+  tmitloss:
+    upstream:
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSPS
+      - BPMSP1D
+      - BPMDAS
+    downstream:
+      - BPMSP2D
+      - BPMSP3D
+      - BPMSP4D
   wire_type: fast
 
 WS31:
@@ -494,26 +506,27 @@ WS31B:
     - LBLMS32A:LTUS
     - TMITLOSS:LTUS
   default_detector: TMITLOSS:LTUS
-  bpms_before_wire:
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSP1S
-    - BPMSP2S
-    - BPMSP3S
-    - BPMSP5S
-    - BPMSP6S
-    - BPMSP7S
-    - BPMSP8S
-    - BPMSP9S
-    - BPMBP36
-  bpms_after_wire:
-    - BPMUE2B
-    - BPMQDB
-    - BPMDDB
+  tmitloss:
+    upstream:
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSP1S
+      - BPMSP2S
+      - BPMSP3S
+      - BPMSP5S
+      - BPMSP6S
+      - BPMSP7S
+      - BPMSP8S
+      - BPMSP9S
+      - BPMBP36
+    downstream:
+      - BPMUE2B
+      - BPMQDB
+      - BPMDDB
   wire_type: fast
 
 WS32B:
@@ -521,26 +534,27 @@ WS32B:
     - LBLMS32A:LTUS
     - TMITLOSS:LTUS
   default_detector: TMITLOSS:LTUS
-  bpms_before_wire:
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSP1S
-    - BPMSP2S
-    - BPMSP3S
-    - BPMSP5S
-    - BPMSP6S
-    - BPMSP7S
-    - BPMSP8S
-    - BPMSP9S
-    - BPMBP36
-  bpms_after_wire:
-    - BPMUE2B
-    - BPMQDB
-    - BPMDDB
+  tmitloss:
+    upstream:
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSP1S
+      - BPMSP2S
+      - BPMSP3S
+      - BPMSP5S
+      - BPMSP6S
+      - BPMSP7S
+      - BPMSP8S
+      - BPMSP9S
+      - BPMBP36
+    downstream:
+      - BPMUE2B
+      - BPMQDB
+      - BPMDDB
   wire_type: fast
 
 WS33B:
@@ -548,26 +562,27 @@ WS33B:
     - LBLMS32A:LTUS
     - TMITLOSS:LTUS
   default_detector: TMITLOSS:LTUS
-  bpms_before_wire:
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSP1S
-    - BPMSP2S
-    - BPMSP3S
-    - BPMSP5S
-    - BPMSP6S
-    - BPMSP7S
-    - BPMSP8S
-    - BPMSP9S
-    - BPMBP36
-  bpms_after_wire:
-    - BPMUE2B
-    - BPMQDB
-    - BPMDDB
+  tmitloss:
+    upstream:
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSP1S
+      - BPMSP2S
+      - BPMSP3S
+      - BPMSP5S
+      - BPMSP6S
+      - BPMSP7S
+      - BPMSP8S
+      - BPMSP9S
+      - BPMBP36
+    downstream:
+      - BPMUE2B
+      - BPMQDB
+      - BPMDDB
   wire_type: fast
 
 WS34B:
@@ -575,24 +590,25 @@ WS34B:
     - LBLMS32A:LTUS
     - TMITLOSS:LTUS
   default_detector: TMITLOSS:LTUS
-  bpms_before_wire:
-    - BPMBP27
-    - BPMBP35
-    - BPMBP28
-    - BPMSPH
-    - BPMSP1
-    - BPMSP2
-    - BPMSP1S
-    - BPMSP2S
-    - BPMSP3S
-    - BPMSP5S
-    - BPMSP6S
-    - BPMSP7S
-    - BPMSP8S
-    - BPMSP9S
-    - BPMBP36
-  bpms_after_wire:
-    - BPMUE2B
-    - BPMQDB
-    - BPMDDB
+  tmitloss:
+    upstream:
+      - BPMBP27
+      - BPMBP35
+      - BPMBP28
+      - BPMSPH
+      - BPMSP1
+      - BPMSP2
+      - BPMSP1S
+      - BPMSP2S
+      - BPMSP3S
+      - BPMSP5S
+      - BPMSP6S
+      - BPMSP7S
+      - BPMSP8S
+      - BPMSP9S
+      - BPMBP36
+    downstream:
+      - BPMUE2B
+      - BPMQDB
+      - BPMDDB
   wire_type: fast

--- a/slac_db/package_data/yaml/BYP.yaml
+++ b/slac_db/package_data/yaml/BYP.yaml
@@ -1813,6 +1813,37 @@ wires:
       - LBLM11A_3:BYP
       - TMITLOSS:BYP
       sum_l_meters: 1212.849
+      tmitloss:
+        downstream:
+        - BPMBP23
+        - BPMBP24
+        - BPMBP25
+        - BPMBP26
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSPS
+        - BPMSP1D
+        - BPMDAS
+        - BPMSP2D
+        - BPMSP3D
+        upstream:
+        - CMB35
+        - BPMX01
+        - BPMX02
+        - BPMDOG1
+        - BPMDOG2
+        - BPMDOG3
+        - BPMDOG6
+        - BPMDOG7
+        - BPMDOG8
+        - BPML2P
+        - BPML3P
+        - BPML4P
+        - BPML5P
       type: WIRE
       wire_type: fast
   WSBP3:
@@ -1900,6 +1931,37 @@ wires:
       - LBLM11A_3:BYP
       - TMITLOSS:BYP
       sum_l_meters: 1416.049
+      tmitloss:
+        downstream:
+        - BPMBP23
+        - BPMBP24
+        - BPMBP25
+        - BPMBP26
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSPS
+        - BPMSP1D
+        - BPMDAS
+        - BPMSP2D
+        - BPMSP3D
+        upstream:
+        - CMB35
+        - BPMX01
+        - BPMX02
+        - BPMDOG1
+        - BPMDOG2
+        - BPMDOG3
+        - BPMDOG6
+        - BPMDOG7
+        - BPMDOG8
+        - BPML2P
+        - BPML3P
+        - BPML4P
+        - BPML5P
       type: WIRE
       wire_type: fast
   WSBP4:
@@ -1987,5 +2049,36 @@ wires:
       - LBLM11A_3:BYP
       - TMITLOSS:BYP
       sum_l_meters: 1619.249
+      tmitloss:
+        downstream:
+        - BPMBP23
+        - BPMBP24
+        - BPMBP25
+        - BPMBP26
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSPS
+        - BPMSP1D
+        - BPMDAS
+        - BPMSP2D
+        - BPMSP3D
+        upstream:
+        - CMB35
+        - BPMX01
+        - BPMX02
+        - BPMDOG1
+        - BPMDOG2
+        - BPMDOG3
+        - BPMDOG6
+        - BPMDOG7
+        - BPMDOG8
+        - BPML2P
+        - BPML3P
+        - BPML4P
+        - BPML5P
       type: WIRE
       wire_type: fast

--- a/slac_db/package_data/yaml/COL1.yaml
+++ b/slac_db/package_data/yaml/COL1.yaml
@@ -886,6 +886,23 @@ wires:
       - LBLM04A:L2B
       - TMITLOSS:COL1
       sum_l_meters: 154.52
+      tmitloss:
+        downstream:
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSPS
+        - BPMSP1D
+        upstream:
+        - BPM1C01
+        - BPM11B
+        - BPMC101
+        - BPMC102
+        - BPMC103
+        - BPMC104
       type: WIRE
       wire_type: fast
   WSC106:
@@ -958,6 +975,23 @@ wires:
       - LBLM04A:L2B
       - TMITLOSS:COL1
       sum_l_meters: 162.52
+      tmitloss:
+        downstream:
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSPS
+        - BPMSP1D
+        upstream:
+        - BPM1C01
+        - BPM11B
+        - BPMC101
+        - BPMC102
+        - BPMC103
+        - BPMC104
       type: WIRE
       wire_type: fast
   WSC108:
@@ -1030,6 +1064,23 @@ wires:
       - LBLM04A:L2B
       - TMITLOSS:COL1
       sum_l_meters: 170.52
+      tmitloss:
+        downstream:
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSPS
+        - BPMSP1D
+        upstream:
+        - BPM1C01
+        - BPM11B
+        - BPMC101
+        - BPMC102
+        - BPMC103
+        - BPMC104
       type: WIRE
       wire_type: fast
   WSC110:
@@ -1102,5 +1153,22 @@ wires:
       - LBLM04A:L2B
       - TMITLOSS:COL1
       sum_l_meters: 178.52
+      tmitloss:
+        downstream:
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSPS
+        - BPMSP1D
+        upstream:
+        - BPM1C01
+        - BPM11B
+        - BPMC101
+        - BPMC102
+        - BPMC103
+        - BPMC104
       type: WIRE
       wire_type: fast

--- a/slac_db/package_data/yaml/DIAG0.yaml
+++ b/slac_db/package_data/yaml/DIAG0.yaml
@@ -773,6 +773,20 @@ wires:
       - SBLM01A:DIAG0
       - LBLM01A:HTR
       - LBLM01B:HTR
+      - TMITLOSS:DIAG0
       sum_l_meters: 57.113
+      tmitloss:
+        downstream:
+        - BPMDG011
+        - BPMDG012
+        upstream:
+        - BPMDG001
+        - BPMDG002
+        - BPMDG003
+        - BPMDG004
+        - BPMDG005
+        - BPMDG0RF
+        - BPMDG008
+        - BPMDG009
       type: WIRE
       wire_type: slow

--- a/slac_db/package_data/yaml/DOG.yaml
+++ b/slac_db/package_data/yaml/DOG.yaml
@@ -1512,5 +1512,36 @@ wires:
       - LBLM11A_3:BYP
       - TMITLOSS:BYP
       sum_l_meters: 1009.649
+      tmitloss:
+        downstream:
+        - BPMBP23
+        - BPMBP24
+        - BPMBP25
+        - BPMBP26
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSPS
+        - BPMSP1D
+        - BPMDAS
+        - BPMSP2D
+        - BPMSP3D
+        upstream:
+        - CMB35
+        - BPMX01
+        - BPMX02
+        - BPMDOG1
+        - BPMDOG2
+        - BPMDOG3
+        - BPMDOG6
+        - BPMS:DOG:215
+        - BPMS:DOG:230
+        - BPML2P
+        - BPML3P
+        - BPML4P
+        - BPML5P
       type: WIRE
       wire_type: fast

--- a/slac_db/package_data/yaml/EMIT2.yaml
+++ b/slac_db/package_data/yaml/EMIT2.yaml
@@ -347,5 +347,18 @@ wires:
       - LBLM07A:L3B
       - TMITLOSS:EMIT2
       sum_l_meters: 384.229
+      tmitloss:
+        downstream:
+        - BPMSP7S
+        - BPMSP8S
+        - BPMSP9S
+        - BPMBP36
+        - BPMBP31
+        - BPMBP32
+        upstream:
+        - BPM2C01
+        - BPM21B
+        - BPME201
+        - BPME202
       type: WIRE
       wire_type: fast

--- a/slac_db/package_data/yaml/HTR.yaml
+++ b/slac_db/package_data/yaml/HTR.yaml
@@ -1168,5 +1168,15 @@ wires:
       - LBLM01B:HTR
       - TMITLOSS:HTR
       sum_l_meters: 24.589
+      tmitloss:
+        downstream:
+        - BPMH2
+        - BPMHD01
+        - BPMHD02
+        - BPMHD03
+        upstream:
+        - BPM2B
+        - BPM0H01
+        - BPM0H04
       type: WIRE
       wire_type: fast

--- a/slac_db/package_data/yaml/L3.yaml
+++ b/slac_db/package_data/yaml/L3.yaml
@@ -4405,7 +4405,19 @@ wires:
       - PMT29150:LI29
       - PMT756:LTUH
       - PMT820:LTUH
+      - TMITLOSS:L3
       sum_l_meters: 700.132
+      tmitloss:
+        downstream:
+        - BPM30501
+        - BPM30601
+        - BPM30701
+        - BPM30801
+        upstream:
+        - BPM27301
+        - BPM27401
+        - BPM27501
+        - BPM27601
       type: WIRE
       wire_type: fast
   WS28144:
@@ -4459,7 +4471,19 @@ wires:
       - PMT29150:LI29
       - PMT756:LTUH
       - PMT820:LTUH
+      - TMITLOSS:L3
       sum_l_meters: 740.508
+      tmitloss:
+        downstream:
+        - BPM30501
+        - BPM30601
+        - BPM30701
+        - BPM30801
+        upstream:
+        - BPM27301
+        - BPM27401
+        - BPM27501
+        - BPM27601
       type: WIRE
       wire_type: fast
   WS28444:
@@ -4513,7 +4537,19 @@ wires:
       - PMT29150:LI29
       - PMT756:LTUH
       - PMT820:LTUH
+      - TMITLOSS:L3
       sum_l_meters: 777.541
+      tmitloss:
+        downstream:
+        - BPM30501
+        - BPM30601
+        - BPM30701
+        - BPM30801
+        upstream:
+        - BPM27301
+        - BPM27401
+        - BPM27501
+        - BPM27601
       type: WIRE
       wire_type: fast
   WS28744:
@@ -4567,6 +4603,18 @@ wires:
       - PMT29150:LI29
       - PMT756:LTUH
       - PMT820:LTUH
+      - TMITLOSS:L3
       sum_l_meters: 814.077
+      tmitloss:
+        downstream:
+        - BPM30501
+        - BPM30601
+        - BPM30701
+        - BPM30801
+        upstream:
+        - BPM27301
+        - BPM27401
+        - BPM27501
+        - BPM27601
       type: WIRE
       wire_type: fast

--- a/slac_db/package_data/yaml/LTUS.yaml
+++ b/slac_db/package_data/yaml/LTUS.yaml
@@ -2845,6 +2845,27 @@ wires:
       - LBLMS32A:LTUS
       - TMITLOSS:LTUS
       sum_l_meters: 3434.508
+      tmitloss:
+        downstream:
+        - BPMUE2B
+        - BPMQDB
+        - BPMDDB
+        upstream:
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSP1S
+        - BPMSP2S
+        - BPMSP3S
+        - BPMSP5S
+        - BPMSP6S
+        - BPMSP7S
+        - BPMSP8S
+        - BPMSP9S
+        - BPMBP36
       type: WIRE
       wire_type: fast
   WS32B:
@@ -2918,6 +2939,27 @@ wires:
       - LBLMS32A:LTUS
       - TMITLOSS:LTUS
       sum_l_meters: 3469.772
+      tmitloss:
+        downstream:
+        - BPMUE2B
+        - BPMQDB
+        - BPMDDB
+        upstream:
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSP1S
+        - BPMSP2S
+        - BPMSP3S
+        - BPMSP5S
+        - BPMSP6S
+        - BPMSP7S
+        - BPMSP8S
+        - BPMSP9S
+        - BPMBP36
       type: WIRE
       wire_type: fast
   WS33B:
@@ -2991,6 +3033,27 @@ wires:
       - LBLMS32A:LTUS
       - TMITLOSS:LTUS
       sum_l_meters: 3505.035
+      tmitloss:
+        downstream:
+        - BPMUE2B
+        - BPMQDB
+        - BPMDDB
+        upstream:
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSP1S
+        - BPMSP2S
+        - BPMSP3S
+        - BPMSP5S
+        - BPMSP6S
+        - BPMSP7S
+        - BPMSP8S
+        - BPMSP9S
+        - BPMBP36
       type: WIRE
       wire_type: fast
   WS34B:
@@ -3064,5 +3127,26 @@ wires:
       - LBLMS32A:LTUS
       - TMITLOSS:LTUS
       sum_l_meters: 3540.299
+      tmitloss:
+        downstream:
+        - BPMUE2B
+        - BPMQDB
+        - BPMDDB
+        upstream:
+        - BPMBP27
+        - BPMBP35
+        - BPMBP28
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSP1S
+        - BPMSP2S
+        - BPMSP3S
+        - BPMSP5S
+        - BPMSP6S
+        - BPMSP7S
+        - BPMSP8S
+        - BPMSP9S
+        - BPMBP36
       type: WIRE
       wire_type: fast

--- a/slac_db/package_data/yaml/SPD.yaml
+++ b/slac_db/package_data/yaml/SPD.yaml
@@ -421,5 +421,17 @@ wires:
       detectors:
       - LBLM22A:SPS
       sum_l_meters: 3024.92
+      tmitloss:
+        downstream:
+        - BPMSP2D
+        - BPMSP3D
+        - BPMSP4D
+        upstream:
+        - BPMSPH
+        - BPMSP1
+        - BPMSP2
+        - BPMSPS
+        - BPMSP1D
+        - BPMDAS
       type: WIRE
       wire_type: fast

--- a/tests/test_db_to_yaml.py
+++ b/tests/test_db_to_yaml.py
@@ -1,0 +1,45 @@
+import os
+import slac_db
+import slac_db.config
+import slac_db.db_to_yaml
+import unittest
+import unittest.util
+import yaml
+
+
+class test_db_to_yaml(unittest.TestCase):
+    def test_compare_yaml(self):
+        unittest.util._MAX_LENGTH = 2000
+        self.maxDiff = None
+
+        def compare_devices(area, test_devices, example_devices):
+            self.assertEqual(
+                {area: sorted(test_devices.keys())},
+                {area: sorted(example_devices.keys())},
+            )
+            for device_type, device in example_devices.items():
+                for name, meta in device.items():
+                    if "pv_cache" in meta["controls_information"]:
+                        del meta["controls_information"]["pv_cache"]
+                    if "hardware" in meta["metadata"]:
+                        del meta["metadata"]["hardware"]
+                    if "tmitloss" in meta["metadata"]:
+                        del meta["metadata"]["tmitloss"]
+                    test_meta = test_devices[device_type][name]
+                    if "tmitloss" in test_meta.get("metadata", {}):
+                        del test_meta["metadata"]["tmitloss"]
+                    self.assertEqual({(area, name): meta}, {(area, name): test_meta})
+
+        def get_yaml_area(location):
+            with open(location, "r") as area_file:
+                return yaml.safe_load(area_file)
+
+        test = slac_db.db_to_yaml.build()
+        yaml_areas = sorted([area[:-5] for area in os.listdir(slac_db.config.yaml())])
+        db_areas = sorted([k for k in test.keys()])
+        self.assertEqual(yaml_areas, db_areas)
+
+        for area in db_areas:
+            compare_devices(
+                area, test[area], get_yaml_area(slac_db.get_yaml(area=area))
+            )

--- a/tests/test_db_to_yaml.py
+++ b/tests/test_db_to_yaml.py
@@ -25,6 +25,12 @@ class test_db_to_yaml(unittest.TestCase):
                         del meta["metadata"]["hardware"]
                     if "tmitloss" in meta["metadata"]:
                         del meta["metadata"]["tmitloss"]
+                    if "detectors" in meta["metadata"]:
+                        meta["metadata"]["detectors"] = [
+                            d
+                            for d in meta["metadata"]["detectors"]
+                            if not d.startswith("TMITLOSS")
+                        ]
                     self.assertEqual(
                         {(area, name): meta},
                         {(area, name): test_devices[device_type][name]},

--- a/tests/test_db_to_yaml.py
+++ b/tests/test_db_to_yaml.py
@@ -23,25 +23,7 @@ class test_db_to_yaml(unittest.TestCase):
                         del meta["controls_information"]["pv_cache"]
                     if "hardware" in meta["metadata"]:
                         del meta["metadata"]["hardware"]
-                    if "tmitloss" in meta["metadata"]:
-                        del meta["metadata"]["tmitloss"]
-                    if "detectors" in meta["metadata"]:
-                        meta["metadata"]["detectors"] = [
-                            d
-                            for d in meta["metadata"]["detectors"]
-                            if not d.startswith("TMITLOSS")
-                        ]
                     test_entry = test_devices[device_type][name]
-                    if "detectors" in test_entry.get("metadata", {}):
-                        test_entry["metadata"]["detectors"] = [
-                            d
-                            for d in test_entry["metadata"]["detectors"]
-                            if not d.startswith("TMITLOSS")
-                        ]
-                    self.assertEqual(
-                        {(area, name): meta},
-                        {(area, name): test_entry},
-                    )
 
         def get_yaml_area(location):
             with open(location, "r") as area_file:

--- a/tests/test_db_to_yaml.py
+++ b/tests/test_db_to_yaml.py
@@ -25,12 +25,9 @@ class test_db_to_yaml(unittest.TestCase):
                         del meta["metadata"]["hardware"]
                     if "tmitloss" in meta["metadata"]:
                         del meta["metadata"]["tmitloss"]
-                    test_meta = test_devices[device_type][name]
-                    if "tmitloss" in test_meta.get("metadata", {}):
-                        del test_meta["metadata"]["tmitloss"]
                     self.assertEqual(
                         {(area, name): meta},
-                        {(area, name): test_meta},
+                        {(area, name): test_devices[device_type][name]},
                     )
 
         def get_yaml_area(location):

--- a/tests/test_db_to_yaml.py
+++ b/tests/test_db_to_yaml.py
@@ -31,9 +31,16 @@ class test_db_to_yaml(unittest.TestCase):
                             for d in meta["metadata"]["detectors"]
                             if not d.startswith("TMITLOSS")
                         ]
+                    test_entry = test_devices[device_type][name]
+                    if "detectors" in test_entry.get("metadata", {}):
+                        test_entry["metadata"]["detectors"] = [
+                            d
+                            for d in test_entry["metadata"]["detectors"]
+                            if not d.startswith("TMITLOSS")
+                        ]
                     self.assertEqual(
                         {(area, name): meta},
-                        {(area, name): test_devices[device_type][name]},
+                        {(area, name): test_entry},
                     )
 
         def get_yaml_area(location):


### PR DESCRIPTION
This pull request refactors Wire TMITLoss metadata to avoid using EPICS control names.  The metadata fields have been reorganized to fall under the 'tmitloss' attribute while being more clearly renamed from `bpms_before_wire` and `bpms_after_wire` to `upstream` and `downstream`. 