### PR TITLE
Consolidate beampath entries for SC_HXR, CU_HXR, and CU_ALINE

### DIFF
--- a/slac_db/package_data/beampaths.yaml
+++ b/slac_db/package_data/beampaths.yaml
@@ -33,8 +33,7 @@ SC_HXR:
   - *SC
   - SPH
   - SLTH
-  - BSYH1
-  - BSYH2
+  - BSYH
   - LTUH
   - UNDH
   - DMPH
@@ -76,10 +75,8 @@ CU: &CU
 
 CU_HXR:
   - *CU
-  - CLTH1
-  - CLTH2
-  - BSYH1
-  - BSYH2
+  - CLTH
+  - BSYH
   - LTUH
   - UNDH
   - DMPH
@@ -94,8 +91,6 @@ CU_SXR:
 
 CU_ALINE:
   - *CU
-  - CLTH1
-  - CLTH2
-  - BSYH1
-  - BSYA1
-  - BSYA2
+  - CLTH
+  - BSYH
+  - BSYA


### PR DESCRIPTION
This pull request simplifies and consolidates beam path identifiers in the `slac_db/package_data/beampaths.yaml` file. The main change is replacing multiple numbered identifiers (such as `BSYH1`, `BSYH2`, `CLTH1`, `CLTH2`, `BSYA1`, `BSYA2`) with their unnumbered counterparts (`BSYH`, `CLTH`, `BSYA`) across several beam path definitions. This makes the configuration more concise and easier to maintain and prevents error print outs for areas that do not have corresponding YAML files.