### PR TITLE
Consolidate beampath entries for SC_HXR, CU_HXR, and CU_ALINE

### DIFF
--- a/slac_db/package_data/beampaths.yaml
+++ b/slac_db/package_data/beampaths.yaml
@@ -33,8 +33,7 @@ SC_HXR:
   - *SC
   - SPH
   - SLTH
-  - BSYH1
-  - BSYH2
+  - BSYH
   - LTUH
   - UNDH
   - DMPH
@@ -76,10 +75,8 @@ CU: &CU
 
 CU_HXR:
   - *CU
-  - CLTH1
-  - CLTH2
-  - BSYH1
-  - BSYH2
+  - CLTH
+  - BSYH
   - LTUH
   - UNDH
   - DMPH
@@ -94,8 +91,6 @@ CU_SXR:
 
 CU_ALINE:
   - *CU
-  - CLTH1
-  - CLTH2
-  - BSYH1
-  - BSYA1
-  - BSYA2
+  - CLTH
+  - BSYH
+  - BSYA


### PR DESCRIPTION
This pull request simplifies and consolidates beam path definitions in the `slac_db/package_data/beampaths.yaml` file by replacing separate segment identifiers with their shared, more general forms. This makes the configuration easier to maintain and reduces redundancy.

**Beampath segment consolidation:**

* Replaced `BSYH1` and `BSYH2` with the single, consolidated `BSYH` entry in both `SC_HXR` and `CU_HXR` beam paths. 
* Replaced `CLTH1` and `CLTH2` with `CLTH`, and `BSYH1`/`BSYH2` with `BSYH` in `CU_HXR` and `CU_ALINE` beam paths. 
* Replaced `BSYA1` and `BSYA2` with `BSYA` in `CU_ALINE` beam path.