### PR TITLE
Rename wire areas IN20 to DL1, LI21 to BC1, and LI28 to L3

### DIFF
--- a/slac_db/package_data/wire_area_metadata.yaml
+++ b/slac_db/package_data/wire_area_metadata.yaml
@@ -1,4 +1,4 @@
-IN20:
+DL1:
   detectors:
   - PMTINJ03:DL1
   - PMTINJ05:DL1
@@ -15,7 +15,7 @@ IN20:
   - IM02
   - IM03
   - BPM2
-LI21:
+BC1:
   detectors:
   - PMT2111:DL1
   - PMT21293:LI21
@@ -45,7 +45,7 @@ LI24:
   - IMBC2I
   - IMBC2O
   - BPM24701
-LI28:
+L3:
   detectors:
   - PMT29150:LI29
   - PMT756:LTUH


### PR DESCRIPTION
Area names in this metadata file are keyed to old MATLAB areas and not the slac-tools designations.