### PR TITLE
Update YAML configurations for charge toroids

### DIFF
--- a/slac_db/package_data/yaml/BC1.yaml
+++ b/slac_db/package_data/yaml/BC1.yaml
@@ -741,8 +741,24 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      charge_toroids:
+      - IMBC1I
+      - IMBC1O
+      - BPMM12
+      default_detector: PMT21350:LI21
+      detectors:
+      - PMT2111:DL1
+      - PMT21293:LI21
+      - PMT2113:LI21
+      - PMT21350:LI21
+      - PMT2114:LI21
+      - PMT2115:LI21
+      jitter_bpms:
+      - BPMM12
+      - BPM21301
       sum_l_meters: 39.56
       type: WIRE
+      wire_type: fast
   WS12:
     controls_information:
       PVs:
@@ -789,8 +805,24 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      charge_toroids:
+      - IMBC1I
+      - IMBC1O
+      - BPMM12
+      default_detector: PMT21350:LI21
+      detectors:
+      - PMT2111:DL1
+      - PMT21293:LI21
+      - PMT2113:LI21
+      - PMT21350:LI21
+      - PMT2114:LI21
+      - PMT2115:LI21
+      jitter_bpms:
+      - BPMM12
+      - BPM21301
       sum_l_meters: 41.217
       type: WIRE
+      wire_type: fast
   WS13:
     controls_information:
       PVs:
@@ -837,5 +869,21 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      charge_toroids:
+      - IMBC1I
+      - IMBC1O
+      - BPMM12
+      default_detector: PMT21350:LI21
+      detectors:
+      - PMT2111:DL1
+      - PMT21293:LI21
+      - PMT2113:LI21
+      - PMT21350:LI21
+      - PMT2114:LI21
+      - PMT2115:LI21
+      jitter_bpms:
+      - BPMM12
+      - BPM21301
       sum_l_meters: 42.873
       type: WIRE
+      wire_type: fast

--- a/slac_db/package_data/yaml/BC2.yaml
+++ b/slac_db/package_data/yaml/BC2.yaml
@@ -417,5 +417,19 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      charge_toroids:
+      - IMBC2I
+      - IMBC2O
+      - BPM24701
+      default_detector: PMT24705:LI24
+      detectors:
+      - PMT24705:LI24
+      - PMT24706:LI24
+      jitter_bpms:
+      - BPM24401
+      - BPM24501
+      - BPM24601
+      - BPM24701
       sum_l_meters: 396.77
       type: WIRE
+      wire_type: slow

--- a/slac_db/package_data/yaml/DL1.yaml
+++ b/slac_db/package_data/yaml/DL1.yaml
@@ -1172,12 +1172,30 @@ wires:
       - CU_SFTH
       - CU_SPEC
       - CU_SXR
+      charge_toroids:
+      - IM01
+      - IM02
+      - IM03
+      - BPM2
+      default_detector: PMTINJ03:DL1
+      detectors:
+      - PMTINJ03:DL1
+      - PMTINJ05:DL1
+      - PMT21350:LI21
+      jitter_bpms:
+      - BPM9
+      - BPM10
+      - BPM11
+      - BPM13
+      - BPM14
       sum_l_meters: 12.175
       type: WIRE
+      wire_type: slow
   WS02:
     controls_information:
       PVs:
         abort_scan: WIRE:IN20:561:MOTR.STOP
+        beam_rate: WIRE:IN20:561:BEAMRATE
         enabled: WIRE:IN20:561:MOTR_ENABLED_STS
         homed: WIRE:IN20:561:MOTR_HOMED_STS
         initialize: WIRE:IN20:561:MOTR_INIT
@@ -1185,9 +1203,11 @@ wires:
         install_angle: WIRE:IN20:561:INSTALLANGLE
         motor: WIRE:IN20:561:MOTR
         motor_rbv: WIRE:IN20:561:MOTR.RBV
+        mps_speed: WIRE:IN20:561:MPSSPEED
         on_status: WIRE:IN20:561:MOTR_ON_STS
         retract: WIRE:IN20:561:MOTR_RETRACT
         scan_pulses: WIRE:IN20:561:SCANPULSES
+        scan_status: WIRE:IN20:561:SCANSTAT
         speed: WIRE:IN20:561:MOTR.VELO
         speed_max: WIRE:IN20:561:MOTR.VMAX
         speed_min: WIRE:IN20:561:MOTR.VBAS
@@ -1218,12 +1238,30 @@ wires:
       - CU_SFTH
       - CU_SPEC
       - CU_SXR
+      charge_toroids:
+      - IM01
+      - IM02
+      - IM03
+      - BPM2
+      default_detector: PMTINJ03:DL1
+      detectors:
+      - PMTINJ03:DL1
+      - PMTINJ05:DL1
+      - PMT21350:LI21
+      jitter_bpms:
+      - BPM9
+      - BPM10
+      - BPM11
+      - BPM13
+      - BPM14
       sum_l_meters: 14.089
       type: WIRE
+      wire_type: fast
   WS03:
     controls_information:
       PVs:
         abort_scan: WIRE:IN20:611:MOTR.STOP
+        beam_rate: WIRE:IN20:611:BEAMRATE
         enabled: WIRE:IN20:611:MOTR_ENABLED_STS
         homed: WIRE:IN20:611:MOTR_HOMED_STS
         initialize: WIRE:IN20:611:MOTR_INIT
@@ -1231,9 +1269,11 @@ wires:
         install_angle: WIRE:IN20:611:INSTALLANGLE
         motor: WIRE:IN20:611:MOTR
         motor_rbv: WIRE:IN20:611:MOTR.RBV
+        mps_speed: WIRE:IN20:611:MPSSPEED
         on_status: WIRE:IN20:611:MOTR_ON_STS
         retract: WIRE:IN20:611:MOTR_RETRACT
         scan_pulses: WIRE:IN20:611:SCANPULSES
+        scan_status: WIRE:IN20:611:SCANSTAT
         speed: WIRE:IN20:611:MOTR.VELO
         speed_max: WIRE:IN20:611:MOTR.VMAX
         speed_min: WIRE:IN20:611:MOTR.VBAS
@@ -1264,8 +1304,25 @@ wires:
       - CU_SFTH
       - CU_SPEC
       - CU_SXR
+      charge_toroids:
+      - IM01
+      - IM02
+      - IM03
+      - BPM2
+      default_detector: PMTINJ03:DL1
+      detectors:
+      - PMTINJ03:DL1
+      - PMTINJ05:DL1
+      - PMT21350:LI21
+      jitter_bpms:
+      - BPM9
+      - BPM10
+      - BPM11
+      - BPM13
+      - BPM14
       sum_l_meters: 16.003
       type: WIRE
+      wire_type: fast
   WS04:
     controls_information:
       PVs:
@@ -1302,5 +1359,22 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      charge_toroids:
+      - IM01
+      - IM02
+      - IM03
+      - BPM2
+      default_detector: PMTINJ05:DL1
+      detectors:
+      - PMTINJ03:DL1
+      - PMTINJ05:DL1
+      - PMT21350:LI21
+      jitter_bpms:
+      - BPM9
+      - BPM10
+      - BPM11
+      - BPM13
+      - BPM14
       sum_l_meters: 18.519
       type: WIRE
+      wire_type: slow

--- a/slac_db/package_data/yaml/L3.yaml
+++ b/slac_db/package_data/yaml/L3.yaml
@@ -4417,8 +4417,45 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      charge_toroids:
+      - BPM2
+      default_detector: PMT29150:LI29
+      detectors:
+      - PMT29150:LI29
+      - PMT756:LTUH
+      - PMT820:LTUH
+      - TMITLOSS:L3
+      jitter_bpms:
+      - BPM27201
+      - BPM27301
+      - BPM27401
+      - BPM27501
+      - BPM27601
+      - BPM27701
+      - BPM27801
+      - BPM27901
+      - BPM28201
+      - BPM28301
+      - BPM28401
+      - BPM28501
+      - BPM28601
+      - BPM28701
+      - BPM28801
+      - BPM28901
       sum_l_meters: 700.132
+      tmitloss:
+        downstream:
+        - BPM30501
+        - BPM30601
+        - BPM30701
+        - BPM30801
+        upstream:
+        - BPM27301
+        - BPM27401
+        - BPM27501
+        - BPM27601
       type: WIRE
+      wire_type: fast
   WS28144:
     controls_information:
       PVs:
@@ -4465,8 +4502,45 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      charge_toroids:
+      - BPM2
+      default_detector: PMT29150:LI29
+      detectors:
+      - PMT29150:LI29
+      - PMT756:LTUH
+      - PMT820:LTUH
+      - TMITLOSS:L3
+      jitter_bpms:
+      - BPM27201
+      - BPM27301
+      - BPM27401
+      - BPM27501
+      - BPM27601
+      - BPM27701
+      - BPM27801
+      - BPM27901
+      - BPM28201
+      - BPM28301
+      - BPM28401
+      - BPM28501
+      - BPM28601
+      - BPM28701
+      - BPM28801
+      - BPM28901
       sum_l_meters: 740.508
+      tmitloss:
+        downstream:
+        - BPM30501
+        - BPM30601
+        - BPM30701
+        - BPM30801
+        upstream:
+        - BPM27301
+        - BPM27401
+        - BPM27501
+        - BPM27601
       type: WIRE
+      wire_type: fast
   WS28444:
     controls_information:
       PVs:
@@ -4513,8 +4587,45 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      charge_toroids:
+      - BPM2
+      default_detector: PMT29150:LI29
+      detectors:
+      - PMT29150:LI29
+      - PMT756:LTUH
+      - PMT820:LTUH
+      - TMITLOSS:L3
+      jitter_bpms:
+      - BPM27201
+      - BPM27301
+      - BPM27401
+      - BPM27501
+      - BPM27601
+      - BPM27701
+      - BPM27801
+      - BPM27901
+      - BPM28201
+      - BPM28301
+      - BPM28401
+      - BPM28501
+      - BPM28601
+      - BPM28701
+      - BPM28801
+      - BPM28901
       sum_l_meters: 777.541
+      tmitloss:
+        downstream:
+        - BPM30501
+        - BPM30601
+        - BPM30701
+        - BPM30801
+        upstream:
+        - BPM27301
+        - BPM27401
+        - BPM27501
+        - BPM27601
       type: WIRE
+      wire_type: fast
   WS28744:
     controls_information:
       PVs:
@@ -4561,5 +4672,42 @@ wires:
       - CU_HXTES
       - CU_SFTH
       - CU_SXR
+      charge_toroids:
+      - BPM2
+      default_detector: PMT29150:LI29
+      detectors:
+      - PMT29150:LI29
+      - PMT756:LTUH
+      - PMT820:LTUH
+      - TMITLOSS:L3
+      jitter_bpms:
+      - BPM27201
+      - BPM27301
+      - BPM27401
+      - BPM27501
+      - BPM27601
+      - BPM27701
+      - BPM27801
+      - BPM27901
+      - BPM28201
+      - BPM28301
+      - BPM28401
+      - BPM28501
+      - BPM28601
+      - BPM28701
+      - BPM28801
+      - BPM28901
       sum_l_meters: 814.077
+      tmitloss:
+        downstream:
+        - BPM30501
+        - BPM30601
+        - BPM30701
+        - BPM30801
+        upstream:
+        - BPM27301
+        - BPM27401
+        - BPM27501
+        - BPM27601
       type: WIRE
+      wire_type: fast


### PR DESCRIPTION
This pull request enhances the configuration of wire scanners in multiple beamline YAML files, adding detailed instrumentation and control metadata. The main updates introduce new fields such as associated charge toroids, detectors, jitter BPMs, and wire types, as well as additional process variable mappings for controls. These changes improve the completeness and usability of the wire scanner database for downstream applications.

The most important changes are:

**Instrumentation and Metadata Additions:**
* Added `charge_toroids`, `default_detector`, `detectors`, and `jitter_bpms` fields to wire scanner entries in `BC1.yaml`, `BC2.yaml`, `DL1.yaml`, and `L3.yaml`, specifying relevant diagnostic devices for each wire. [[1]](diffhunk://#diff-90afa394a7eff87828c531340b98bb61985b8719356f8a615e19d6966c59f13cR744-R761) [[2]](diffhunk://#diff-90afa394a7eff87828c531340b98bb61985b8719356f8a615e19d6966c59f13cR808-R825) [[3]](diffhunk://#diff-90afa394a7eff87828c531340b98bb61985b8719356f8a615e19d6966c59f13cR872-R889) [[4]](diffhunk://#diff-08ced712e7c687e0d2efd659dafd6c0656e89e03d292f154630fd1161e30b9d8R420-R435) [[5]](diffhunk://#diff-fa97fcf7aded1f74f882b7368961ee78357abb788c676c19b65051437f1e5610R1175-R1210) [[6]](diffhunk://#diff-fa97fcf7aded1f74f882b7368961ee78357abb788c676c19b65051437f1e5610R1241-R1276) [[7]](diffhunk://#diff-fa97fcf7aded1f74f882b7368961ee78357abb788c676c19b65051437f1e5610R1307-R1325) [[8]](diffhunk://#diff-fa97fcf7aded1f74f882b7368961ee78357abb788c676c19b65051437f1e5610R1362-R1380) [[9]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4420-R4458) [[10]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4505-R4543) [[11]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4590-R4628) [[12]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4675-R4713)
* Added `wire_type` field (e.g., `fast` or `slow`) to wire scanner definitions for clearer categorization. [[1]](diffhunk://#diff-90afa394a7eff87828c531340b98bb61985b8719356f8a615e19d6966c59f13cR744-R761) [[2]](diffhunk://#diff-90afa394a7eff87828c531340b98bb61985b8719356f8a615e19d6966c59f13cR808-R825) [[3]](diffhunk://#diff-90afa394a7eff87828c531340b98bb61985b8719356f8a615e19d6966c59f13cR872-R889) [[4]](diffhunk://#diff-08ced712e7c687e0d2efd659dafd6c0656e89e03d292f154630fd1161e30b9d8R420-R435) [[5]](diffhunk://#diff-fa97fcf7aded1f74f882b7368961ee78357abb788c676c19b65051437f1e5610R1175-R1210) [[6]](diffhunk://#diff-fa97fcf7aded1f74f882b7368961ee78357abb788c676c19b65051437f1e5610R1241-R1276) [[7]](diffhunk://#diff-fa97fcf7aded1f74f882b7368961ee78357abb788c676c19b65051437f1e5610R1307-R1325) [[8]](diffhunk://#diff-fa97fcf7aded1f74f882b7368961ee78357abb788c676c19b65051437f1e5610R1362-R1380) [[9]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4420-R4458) [[10]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4505-R4543) [[11]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4590-R4628) [[12]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4675-R4713)
* For L3 wire scanners, introduced a `tmitloss` field with upstream and downstream BPMs for improved charge loss monitoring. [[1]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4420-R4458) [[2]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4505-R4543) [[3]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4590-R4628) [[4]](diffhunk://#diff-10d115934057ce6d5dfc4fe7d4477d056766a5b7f4cbb74921c7f9215b95e117R4675-R4713)

**Controls Integration:**
* Expanded the `controls_information.PVs` mapping for DL1 wire scanners to include new process variables such as `beam_rate`, `mps_speed`, and `scan_status`, supporting enhanced operational control and monitoring. [[1]](diffhunk://#diff-fa97fcf7aded1f74f882b7368961ee78357abb788c676c19b65051437f1e5610R1175-R1210) [[2]](diffhunk://#diff-fa97fcf7aded1f74f882b7368961ee78357abb788c676c19b65051437f1e5610R1241-R1276)

These updates standardize and enrich the wire scanner database, enabling more robust diagnostics and streamlined integration with control systems.