### PR TITLE
Add is-active and use it 

### DIFF
--- a/slac_db/create/combined.py
+++ b/slac_db/create/combined.py
@@ -205,8 +205,9 @@ class _Parser:
                     "area": r["area"],
                     "device_type": r["keyword"],
                     "cs_name": r["control system name"],
+                    "is_active": r["active"] == "A" if r["active"] is not None else None,
                 }
-                if None in yv.values() or ":" in r["element"]:
+                if any(v is None for k, v in yv.items() if k != "is_active") or ":" in r["element"]:
                     continue
                 yield yv
 

--- a/slac_db/device.py
+++ b/slac_db/device.py
@@ -22,12 +22,14 @@ def get_areas(beampath=None):
         )
         return sorted([a["area"] for a in s.select(selection)])
 
-def get_beampath(beampath=None, device_type=None):
+def get_beampath(beampath=None, device_type=None, include_inactive=False):
     """ Get all devices in a beampath, optionally by type.
 
     Args:
         beampath (str): Beampath name
         device_type (str) optional: Device type in Oracle
+        include_inactive (bool) optional: If True, include inactive devices.
+            Defaults to False (active devices only).
 
     Out:
         List of devices in alphabetical order.
@@ -37,6 +39,8 @@ def get_beampath(beampath=None, device_type=None):
         selection = selection.where(s.t.beampaths.c["beampath"] == beampath)
         if device_type is not None:
             selection = selection.where(s.t.devices.c["device_type"] == device_type)
+        if not include_inactive:
+            selection = selection.where(s.t.devices.c["is_active"] == True)
         return sorted([d["device_name"] for d in s.select(selection)])
 
 def get_attribute(device_name, col_name):
@@ -57,12 +61,14 @@ def get_attribute(device_name, col_name):
             )
         )[col_name]
 
-def get_devices(area=None, device_type=None):
+def get_devices(area=None, device_type=None, include_inactive=False):
     """ Get all devices in an area of a type.
 
     Args:
         area (str) optional: Area name
         device_type (str) optional: Device type in Oracle
+        include_inactive (bool) optional: If True, include inactive devices.
+            Defaults to False (active devices only).
 
     Out:
         List of devices in alphabetical order.
@@ -73,6 +79,8 @@ def get_devices(area=None, device_type=None):
             selection = selection.where(s.t.devices.c["area"] == area)
         if device_type is not None:
             selection = selection.where(s.t.devices.c["device_type"] == device_type)
+        if not include_inactive:
+            selection = selection.where(s.t.devices.c["is_active"] == True)
         return sorted([d["device_name"] for d in s.select(selection)])
 
 def get_all_accessors(device):
@@ -284,7 +292,8 @@ def _init_db(location=None):
             "device_name": "str 64 primary_key",
             "area": "str 64 foreign",
             "device_type": "str 64",
-            "cs_name": "str 64"
+            "cs_name": "str 64",
+            "is_active": "bool nullable",
         },
         "device_meta": {
             "device_name": "str 64 primary_key foreign",

--- a/slac_db/oracle.py
+++ b/slac_db/oracle.py
@@ -188,7 +188,8 @@ def _init_db(location=None):
             "SumL (m)": "float 64 nullable",
             "Effective Length (m)": "float 64 nullable",
             "Rf Frequency (MHz)": "float 64 nullable",
-            "Engineering Name": "str 64 nullable"
+            "Engineering Name": "str 64 nullable",
+            "Active": "str 1 nullable",
         }
     }
     _meta = pykern.sql_db.Meta(

--- a/slac_db/package_data/device.sqlite3
+++ b/slac_db/package_data/device.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05a316edcbf933518c5d197efcd3937ce27a3cc2866170bdc563a629542cf664
-size 210288640
+oid sha256:b1ab0a6673e1fab1157630affe0e92693c035a31377c398a6dfd526f6cdc81e2
+size 210292736

--- a/slac_db/package_data/lcls_elements.sqlite3
+++ b/slac_db/package_data/lcls_elements.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e840beebf31a2c1df42c58c8be76f5714271e6c3273fcebb9cf21a9d370f6269
-size 942080
+oid sha256:f6debf1e55ccdea579e3fe3fee50db7bd945a035b965339f4d8fee369cc4bdd4
+size 958464

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -18,3 +18,28 @@ class test_device(unittest.TestCase):
         value = slac_db.device.get_devices(area="DIAG0", device_type="PROF")
         expected = ["OTRDG02", "OTRDG04"]
         self.assertEqual(value, expected)
+
+    def test_is_active_attribute(self):
+        """Active devices have is_active=True, inactive have is_active=False."""
+        # OTRDG02 is an active screen in DIAG0
+        self.assertTrue(slac_db.device.get_attribute("OTRDG02", "is_active"))
+        # BLRDG0T is an inactive TRIM in DIAG0
+        self.assertFalse(slac_db.device.get_attribute("BLRDG0T", "is_active"))
+
+    def test_get_devices_exclude_inactive(self):
+        """By default inactive devices are excluded."""
+        all_devices = slac_db.device.get_devices(area="DIAG0", device_type="TRIM", include_inactive=True)
+        active_devices = slac_db.device.get_devices(area="DIAG0", device_type="TRIM")
+        self.assertIn("BLRDG0T", all_devices)
+        self.assertNotIn("BLRDG0T", active_devices)
+        self.assertTrue(len(active_devices) < len(all_devices))
+
+    def test_get_beampath_exclude_inactive(self):
+        """By default inactive devices are excluded; include_inactive=True brings them back."""
+        active_lcav = slac_db.device.get_beampath(beampath="CU_HXR", device_type="LCAV")
+        all_lcav = slac_db.device.get_beampath(beampath="CU_HXR", device_type="LCAV", include_inactive=True)
+        # active results must be a strict subset
+        self.assertTrue(set(active_lcav).issubset(set(all_lcav)))
+        # L0A___ is the known inactive element — excluded by default, present with flag
+        self.assertNotIn("L0A___", active_lcav)
+        self.assertIn("L0A___", all_lcav)


### PR DESCRIPTION
Title: Add is_active flag from lcls_elements.csv to device database

Branch: update_db

## Problem

`slac_db.device.get_beampath(beampath='CU_HXR', device_type='LCAV')` returns
both active elements (e.g. `L0A`) and inactive elements (e.g. `L0A___`).
The `Active` column already exists in `lcls_elements.csv` (column index 11,
values `A` = active, `I` = inactive) but was never carried through the
pipeline into either SQLite database.

## Changes

### slac_db/oracle.py
Add `"Active": "str 1 nullable"` to the `lcls_elements.sqlite3` schema.
The existing `_Inserter._rows` already iterates schema columns and looks up
`r[c.name.lower()]` from the CSV row dict, so no additional parser changes
are needed — the value flows through automatically.

### slac_db/device.py
- Add `"is_active": "bool nullable"` to the `devices` table schema in
  `device.sqlite3`.
- Add `include_inactive=False` parameter to `get_beampath()` and
  `get_devices()`. The default (`False`) returns only active devices. Pass
  `include_inactive=True` to get all devices regardless of active status.

### slac_db/create/combined.py
In `_Parser._devices()`, populate `is_active` for each device row:
  - `True`  if `r["active"] == "A"`
  - `False` if `r["active"] == "I"`
  - `None`  if the `Active` field is missing from the source row

The `None`-check that skips incomplete rows is updated to exclude `is_active`
from that check (a missing active flag does not disqualify a device).

### tests/test_device.py
Three new test cases:
- `test_is_active_attribute` — verifies `OTRDG02` (active) and `BLRDG0T`
  (inactive) have the correct `is_active` values in the rebuilt DB.
- `test_get_devices_exclude_inactive` — verifies the default call excludes
  the known inactive TRIM `BLRDG0T` from `DIAG0`, and `include_inactive=True`
  brings it back.
- `test_get_beampath_exclude_inactive` — verifies the default call on
  `CU_HXR / LCAV` excludes `L0A___` (the element that prompted this fix),
  and `include_inactive=True` brings it back.

## Usage after this change

```python
import slac_db.device as dev

# Default — active devices only (new behaviour)
dev.get_beampath(beampath='CU_HXR', device_type='LCAV')

# Explicit — include inactive devices too
dev.get_beampath(beampath='CU_HXR', device_type='LCAV', include_inactive=True)

# Also works on get_devices
dev.get_devices(area='L1', device_type='LCAV')                      # active only
dev.get_devices(area='L1', device_type='LCAV', include_inactive=True)  # all

# Inspect the flag directly
dev.get_attribute('L0A___', 'is_active')   # False
dev.get_attribute('L0A',    'is_active')   # True
```

## Database rebuild required 

Both SQLite files must be regenerated after pulling this branch:

```python
import slac_db.create.lcls_elements as le
le.to_oracle_db()          # rebuilds lcls_elements.sqlite3

import slac_db.create.combined as c
c.to_device_db()           # rebuilds device.sqlite3
```

The shipped copies in `slac_db/package_data/` have been updated and are
included in this PR.

## Files changed

  modified: slac_db/oracle.py
  modified: slac_db/device.py
  modified: slac_db/create/combined.py
  modified: slac_db/package_data/lcls_elements.sqlite3
  modified: slac_db/package_data/device.sqlite3
  modified: tests/test_device.py
